### PR TITLE
Add mobile SSH editing, GitHub sync, and packages

### DIFF
--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -19,7 +19,24 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed lib test
       - run: flutter analyze
       - run: flutter test
-      - run: flutter build apk --debug
+      - name: Build Android release APK
+        run: flutter build apk --release
+      - name: Prepare Android package
+        shell: bash
+        run: |
+          mkdir -p dist
+          cp build/app/outputs/flutter-apk/app-release.apk dist/netcatty-mobile-android.apk
+          cd dist
+          sha256sum netcatty-mobile-android.apk > netcatty-mobile-android.apk.sha256
+      - name: Upload Android package
+        uses: actions/upload-artifact@v4
+        with:
+          name: netcatty-mobile-android-${{ github.run_number }}
+          path: |
+            dist/netcatty-mobile-android.apk
+            dist/netcatty-mobile-android.apk.sha256
+          if-no-files-found: error
+          retention-days: 30
 
   ios:
     runs-on: macos-15

--- a/.github/workflows/mobile.yml
+++ b/.github/workflows/mobile.yml
@@ -20,7 +20,7 @@ jobs:
       - run: flutter analyze
       - run: flutter test
       - name: Build Android release APK
-        run: flutter build apk --release
+        run: flutter build apk --release --dart-define=GITHUB_OAUTH_CLIENT_ID=Ov23lidR2u8OIkHW19nk
       - name: Prepare Android package
         shell: bash
         run: |
@@ -48,4 +48,23 @@ jobs:
           flutter-version: 3.44.4
           cache: true
       - run: flutter pub get
-      - run: flutter build ios --debug --no-codesign
+      - name: Build unsigned iOS release app
+        run: flutter build ios --release --no-codesign --dart-define=GITHUB_OAUTH_CLIENT_ID=Ov23lidR2u8OIkHW19nk
+      - name: Package re-signable IPA
+        shell: bash
+        run: |
+          mkdir -p dist build/ios/iphoneos/Payload
+          cp -R build/ios/iphoneos/Runner.app build/ios/iphoneos/Payload/
+          cd build/ios/iphoneos
+          ditto -c -k --sequesterRsrc --keepParent Payload ../../../dist/netcatty-mobile-ios-unsigned.ipa
+          cd ../../../dist
+          shasum -a 256 netcatty-mobile-ios-unsigned.ipa > netcatty-mobile-ios-unsigned.ipa.sha256
+      - name: Upload re-signable IPA
+        uses: actions/upload-artifact@v4
+        with:
+          name: netcatty-mobile-ios-unsigned-${{ github.run_number }}
+          path: |
+            dist/netcatty-mobile-ios-unsigned.ipa
+            dist/netcatty-mobile-ios-unsigned.ipa.sha256
+          if-no-files-found: error
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ flutter build apk --release
 flutter build appbundle --release
 ```
 
+## 下载自动构建的 Android 安装包
+
+打开仓库的 **Actions** 页面，进入最新一个成功的 **Mobile CI** 任务，在页面底部的 **Artifacts** 区域下载
+`netcatty-mobile-android-<运行编号>`。解压后包含：
+
+- `netcatty-mobile-android.apk`：可直接安装的 Android Release APK
+- `netcatty-mobile-android.apk.sha256`：安装包完整性校验值
+
+自动构建产物保留 30 天。当前 APK 使用调试密钥签名，适合测试与自行安装；正式上架前请配置专用发布密钥。
+
 iOS 构建（需先在 Xcode 设置开发团队和签名）：
 
 ```bash
@@ -50,7 +60,7 @@ flutter build ios --release
 open ios/Runner.xcworkspace
 ```
 
-发布前请把 `android/app/build.gradle` 的 debug signingConfig 替换成正式签名，并在 Xcode 设置唯一 Bundle ID、Team、App Store 图标和隐私清单。
+发布前请把 `android/app/build.gradle.kts` 的 debug signingConfig 替换成正式签名，并在 Xcode 设置唯一 Bundle ID、Team、App Store 图标和隐私清单。
 
 ## 与桌面端同步
 
@@ -72,4 +82,3 @@ test                加密兼容与模型无损测试
 ## License
 
 GPL-3.0-or-later，延续上游 [binaricat/Netcatty](https://github.com/binaricat/Netcatty) 的许可证。
-

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
     <application
         android:label="Netcatty"
@@ -32,6 +35,14 @@
                 <data android:scheme="ssh" />
             </intent-filter>
         </activity>
+        <service
+            android:name=".SshKeepAliveService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Keeps user-initiated interactive SSH terminal sessions connected while the app is backgrounded." />
+        </service>
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />

--- a/android/app/src/main/kotlin/app/netcatty/mobile/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/netcatty/mobile/MainActivity.kt
@@ -1,5 +1,53 @@
 package app.netcatty.mobile
 
+import android.Manifest
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugin.common.MethodChannel
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterActivity() {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        super.configureFlutterEngine(flutterEngine)
+        MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "app.netcatty.mobile/connection",
+        ).setMethodCallHandler { call, result ->
+            when (call.method) {
+                "setActive" -> {
+                    val active = call.argument<Boolean>("active") == true
+                    if (active) {
+                        requestNotificationPermission()
+                        ContextCompat.startForegroundService(
+                            this,
+                            Intent(this, SshKeepAliveService::class.java),
+                        )
+                    } else {
+                        stopService(Intent(this, SshKeepAliveService::class.java))
+                    }
+                    result.success(null)
+                }
+                "beginBackgroundGrace", "endBackgroundGrace" -> result.success(null)
+                else -> result.notImplemented()
+            }
+        }
+    }
+
+    private fun requestNotificationPermission() {
+        if (
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            ActivityCompat.requestPermissions(
+                this,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                701,
+            )
+        }
+    }
+}

--- a/android/app/src/main/kotlin/app/netcatty/mobile/SshKeepAliveService.kt
+++ b/android/app/src/main/kotlin/app/netcatty/mobile/SshKeepAliveService.kt
@@ -1,0 +1,67 @@
+package app.netcatty.mobile
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+
+class SshKeepAliveService : Service() {
+    companion object {
+        private const val CHANNEL_ID = "netcatty_ssh_sessions"
+        private const val NOTIFICATION_ID = 701
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        createChannel()
+        startForeground(NOTIFICATION_ID, buildNotification())
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
+        START_STICKY
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun createChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+        val manager = getSystemService(NotificationManager::class.java)
+        manager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                "SSH 会话",
+                NotificationManager.IMPORTANCE_LOW,
+            ).apply {
+                description = "保持正在使用的 SSH 连接"
+                setShowBadge(false)
+            },
+        )
+    }
+
+    private fun buildNotification(): Notification {
+        val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+        val builder = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            Notification.Builder(this, CHANNEL_ID)
+        } else {
+            @Suppress("DEPRECATION")
+            Notification.Builder(this)
+        }
+        return builder
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("Netcatty SSH 会话正在运行")
+            .setContentText("点击返回终端；关闭全部会话后服务会自动停止")
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setCategory(Notification.CATEGORY_SERVICE)
+            .build()
+    }
+}

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -3,6 +3,8 @@ import UIKit
 
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+  private var sshBackgroundTask: UIBackgroundTaskIdentifier = .invalid
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
@@ -12,5 +14,38 @@ import UIKit
 
   func didInitializeImplicitFlutterEngine(_ engineBridge: FlutterImplicitEngineBridge) {
     GeneratedPluginRegistrant.register(with: engineBridge.pluginRegistry)
+    let channel = FlutterMethodChannel(
+      name: "app.netcatty.mobile/connection",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+    channel.setMethodCallHandler { [weak self] call, result in
+      switch call.method {
+      case "beginBackgroundGrace":
+        self?.beginSshBackgroundGrace()
+        result(nil)
+      case "endBackgroundGrace":
+        self?.endSshBackgroundGrace()
+        result(nil)
+      case "setActive":
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private func beginSshBackgroundGrace() {
+    guard sshBackgroundTask == .invalid else { return }
+    sshBackgroundTask = UIApplication.shared.beginBackgroundTask(
+      withName: "Finish active SSH network work"
+    ) { [weak self] in
+      self?.endSshBackgroundGrace()
+    }
+  }
+
+  private func endSshBackgroundGrace() {
+    guard sshBackgroundTask != .invalid else { return }
+    UIApplication.shared.endBackgroundTask(sshBackgroundTask)
+    sshBackgroundTask = .invalid
   }
 }

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,14 +3,51 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'application/settings_controller.dart';
+import 'application/session_controller.dart';
+import 'infrastructure/ssh/connection_platform_service.dart';
 import 'presentation/home_shell.dart';
 import 'presentation/theme.dart';
 
-class NetcattyApp extends ConsumerWidget {
+class NetcattyApp extends ConsumerStatefulWidget {
   const NetcattyApp({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<NetcattyApp> createState() => _NetcattyAppState();
+}
+
+class _NetcattyAppState extends ConsumerState<NetcattyApp>
+    with WidgetsBindingObserver {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      ConnectionPlatformService.endBackgroundGrace();
+      ref.read(sessionControllerProvider.notifier).reconnectDisconnected();
+    } else if (state == AppLifecycleState.paused ||
+        state == AppLifecycleState.hidden) {
+      ConnectionPlatformService.beginBackgroundGrace();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    ref.listen<bool>(
+      sessionControllerProvider.select(
+        (value) => value.sessions.any((session) => session.connected),
+      ),
+      (previous, next) => ConnectionPlatformService.setActive(next),
+    );
     final settings = ref.watch(settingsControllerProvider);
     final mode = switch (settings.themeMode) {
       'light' => ThemeMode.light,

--- a/lib/application/session_controller.dart
+++ b/lib/application/session_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
 
 import '../domain/models/host.dart';
 import '../infrastructure/ssh/ssh_service.dart';
@@ -47,24 +48,20 @@ class SessionController extends StateNotifier<SessionState> {
     HostKeyVerifier verifyHostKey, {
     KeyboardInteractiveHandler? keyboardInteractive,
   }) async {
-    final existing = state.sessions.indexWhere(
-      (item) => item.host.id == host.id,
-    );
-    if (existing >= 0) {
-      state = SessionState(sessions: state.sessions, activeIndex: existing);
-      return;
-    }
     state = SessionState(
       sessions: state.sessions,
       activeIndex: state.activeIndex,
       connectingHostId: host.id,
     );
     try {
-      final keys = ref.read(vaultControllerProvider).data?.keys ??
-          const <SshKeyProfile>[];
+      final vault = ref.read(vaultControllerProvider).data;
+      final keys = vault?.keys ?? const <SshKeyProfile>[];
       final session = await service.connect(
+        sessionId: const Uuid().v4(),
         host: host,
+        hosts: vault?.hosts ?? const <HostProfile>[],
         keys: keys,
+        proxyProfiles: vault?.proxyProfiles ?? const <ProxyProfile>[],
         verifyHostKey: verifyHostKey,
         keyboardInteractive: keyboardInteractive,
       );
@@ -73,6 +70,7 @@ class SessionController extends StateNotifier<SessionState> {
         sessions: sessions,
         activeIndex: sessions.length - 1,
       );
+      _watchSession(session);
       unawaited(vaultController.markConnected(host));
     } catch (error) {
       state = SessionState(
@@ -82,6 +80,62 @@ class SessionController extends StateNotifier<SessionState> {
       );
       rethrow;
     }
+  }
+
+  Future<void> reconnectDisconnected() async {
+    if (state.connectingHostId != null) return;
+    for (final old in [...state.sessions]) {
+      if (old.connected || old.closedByUser) continue;
+      final index = state.sessions.indexWhere((value) => value.id == old.id);
+      if (index < 0) continue;
+      state = SessionState(
+        sessions: state.sessions,
+        activeIndex: state.activeIndex,
+        connectingHostId: old.host.id,
+      );
+      try {
+        final vault = ref.read(vaultControllerProvider).data;
+        old.terminal.write('\r\n\x1b[33m正在恢复连接…\x1b[0m\r\n');
+        final replacement = await service.connect(
+          sessionId: old.id,
+          host: old.host,
+          hosts: vault?.hosts ?? const <HostProfile>[],
+          keys: vault?.keys ?? const <SshKeyProfile>[],
+          proxyProfiles: vault?.proxyProfiles ?? const <ProxyProfile>[],
+          verifyHostKey: old.verifyHostKey,
+          keyboardInteractive: old.keyboardInteractive,
+          terminal: old.terminal,
+        );
+        final sessions = [...state.sessions];
+        final current = sessions.indexWhere((value) => value.id == old.id);
+        if (current >= 0) sessions[current] = replacement;
+        state = SessionState(
+          sessions: sessions,
+          activeIndex: state.activeIndex.clamp(0, sessions.length - 1),
+        );
+        _watchSession(replacement);
+      } catch (error) {
+        old.terminal.write('\r\n\x1b[31m恢复连接失败：$error\x1b[0m\r\n');
+        state = SessionState(
+          sessions: state.sessions,
+          activeIndex: state.activeIndex,
+          error: error,
+        );
+      }
+    }
+  }
+
+  void _watchSession(ActiveTerminalSession session) {
+    unawaited(session.done.then((_) {
+      if (session.closedByUser) return;
+      session.connected = false;
+      session.terminal.write('\r\n\x1b[33m连接已断开，返回前台后将自动重连。\x1b[0m\r\n');
+      if (!mounted) return;
+      state = SessionState(
+        sessions: [...state.sessions],
+        activeIndex: state.activeIndex,
+      );
+    }));
   }
 
   void activate(int index) {

--- a/lib/domain/models/host.dart
+++ b/lib/domain/models/host.dart
@@ -4,6 +4,60 @@ enum HostProtocol { ssh, telnet, mosh }
 
 enum HostAuthMethod { auto, password, key }
 
+enum ProxyType { http, socks5 }
+
+class ProxyConfig {
+  const ProxyConfig({
+    required this.type,
+    required this.host,
+    required this.port,
+    this.username,
+    this.password,
+  });
+
+  factory ProxyConfig.fromJson(Map<String, dynamic> json) => ProxyConfig(
+        type: ProxyType.values.firstWhere(
+          (value) => value.name == json['type'],
+          orElse: () => ProxyType.http,
+        ),
+        host: json['host']?.toString() ?? '',
+        port: (json['port'] as num?)?.toInt() ?? 0,
+        username: json['username']?.toString(),
+        password: json['password']?.toString(),
+      );
+
+  final ProxyType type;
+  final String host;
+  final int port;
+  final String? username;
+  final String? password;
+
+  Map<String, dynamic> toJson() => {
+        'type': type.name,
+        'host': host,
+        'port': port,
+        if (username?.isNotEmpty == true) 'username': username,
+        if (password?.isNotEmpty == true) 'password': password,
+      };
+}
+
+class ProxyProfile {
+  ProxyProfile(Map<String, dynamic> value)
+      : data = Map<String, dynamic>.from(value);
+
+  final Map<String, dynamic> data;
+  String get id => data['id']?.toString() ?? '';
+  String get label => data['label']?.toString() ?? 'Proxy';
+  ProxyConfig? get config {
+    final value = data['config'];
+    return value is Map
+        ? ProxyConfig.fromJson(Map<String, dynamic>.from(value))
+        : null;
+  }
+
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(data);
+}
+
 /// A lossless view over Netcatty's desktop Host JSON model.
 ///
 /// Unknown desktop/plugin fields remain in [data] and survive every save/sync.
@@ -45,6 +99,27 @@ class HostProfile {
   String? get group => data['group']?.toString();
   String? get password => data['password']?.toString();
   String? get identityFileId => data['identityFileId']?.toString();
+  HostAuthMethod get authMethod => HostAuthMethod.values.firstWhere(
+        (value) => value.name == data['authMethod'],
+        orElse: () => HostAuthMethod.auto,
+      );
+  List<String> get hostChainIds {
+    final chain = data['hostChain'];
+    if (chain is! Map) return const [];
+    return (chain['hostIds'] as List? ?? const [])
+        .map((value) => value.toString())
+        .where((value) => value.isNotEmpty)
+        .toList(growable: false);
+  }
+
+  String? get proxyProfileId => data['proxyProfileId']?.toString();
+  ProxyConfig? get proxyConfig {
+    final value = data['proxyConfig'];
+    return value is Map
+        ? ProxyConfig.fromJson(Map<String, dynamic>.from(value))
+        : null;
+  }
+
   String? get startupCommand => data['startupCommand']?.toString();
   bool get pinned => data['pinned'] == true;
   int get lastConnectedAt => (data['lastConnectedAt'] as num?)?.toInt() ?? 0;
@@ -64,6 +139,10 @@ class HostProfile {
     String? group,
     String? password,
     String? identityFileId,
+    HostAuthMethod? authMethod,
+    List<String>? hostChainIds,
+    String? proxyProfileId,
+    ProxyConfig? proxyConfig,
     List<String>? tags,
     HostProtocol? protocol,
     bool? pinned,
@@ -87,6 +166,14 @@ class HostProfile {
     if (identityFileId != null) {
       set('identityFileId', identityFileId.isEmpty ? null : identityFileId);
     }
+    if (authMethod != null) set('authMethod', authMethod.name);
+    if (hostChainIds != null) {
+      set('hostChain', hostChainIds.isEmpty ? null : {'hostIds': hostChainIds});
+    }
+    if (proxyProfileId != null) {
+      set('proxyProfileId', proxyProfileId.isEmpty ? null : proxyProfileId);
+    }
+    if (proxyConfig != null) set('proxyConfig', proxyConfig.toJson());
     if (tags != null) set('tags', tags);
     if (protocol != null) set('protocol', protocol.name);
     if (pinned != null) set('pinned', pinned);

--- a/lib/domain/models/settings.dart
+++ b/lib/domain/models/settings.dart
@@ -7,6 +7,7 @@ class AppSettings {
     this.language = 'zh-CN',
     this.aiEndpoint = 'https://api.openai.com/v1',
     this.aiModel = 'gpt-4.1-mini',
+    this.terminalQuickKeys = defaultTerminalQuickKeys,
   });
 
   factory AppSettings.fromJson(Map<String, dynamic> json) => AppSettings(
@@ -16,6 +17,11 @@ class AppSettings {
         aiEndpoint:
             json['aiEndpoint']?.toString() ?? 'https://api.openai.com/v1',
         aiModel: json['aiModel']?.toString() ?? 'gpt-4.1-mini',
+        terminalQuickKeys:
+            (json['terminalQuickKeys'] as List? ?? defaultTerminalQuickKeys)
+                .map((value) => value.toString())
+                .where(defaultTerminalQuickKeys.contains)
+                .toList(),
       );
 
   final String themeMode;
@@ -23,6 +29,7 @@ class AppSettings {
   final String language;
   final String aiEndpoint;
   final String aiModel;
+  final List<String> terminalQuickKeys;
 
   AppSettings copyWith({
     String? themeMode,
@@ -30,6 +37,7 @@ class AppSettings {
     String? language,
     String? aiEndpoint,
     String? aiModel,
+    List<String>? terminalQuickKeys,
   }) =>
       AppSettings(
         themeMode: themeMode ?? this.themeMode,
@@ -37,6 +45,7 @@ class AppSettings {
         language: language ?? this.language,
         aiEndpoint: aiEndpoint ?? this.aiEndpoint,
         aiModel: aiModel ?? this.aiModel,
+        terminalQuickKeys: terminalQuickKeys ?? this.terminalQuickKeys,
       );
 
   Map<String, dynamic> toJson() => {
@@ -45,8 +54,25 @@ class AppSettings {
         'language': language,
         'aiEndpoint': aiEndpoint,
         'aiModel': aiModel,
+        'terminalQuickKeys': terminalQuickKeys,
       };
 }
+
+const defaultTerminalQuickKeys = <String>[
+  'escape',
+  'tab',
+  'ctrlC',
+  'ctrlD',
+  'ctrlZ',
+  'arrowUp',
+  'arrowDown',
+  'arrowLeft',
+  'arrowRight',
+  'pipe',
+  'slash',
+  'tilde',
+  'hideKeyboard',
+];
 
 class SyncConnection {
   const SyncConnection({

--- a/lib/domain/models/vault.dart
+++ b/lib/domain/models/vault.dart
@@ -6,6 +6,7 @@ class VaultData {
     required this.keys,
     required this.snippets,
     required this.customGroups,
+    this.proxyProfiles = const [],
     Map<String, dynamic>? extras,
   }) : extras = extras ?? <String, dynamic>{};
 
@@ -18,6 +19,7 @@ class VaultData {
       ..remove('keys')
       ..remove('snippets')
       ..remove('customGroups');
+    extras.remove('proxyProfiles');
     return VaultData(
       hosts: (json['hosts'] as List? ?? const [])
           .whereType<Map>()
@@ -34,6 +36,10 @@ class VaultData {
       customGroups: (json['customGroups'] as List? ?? const [])
           .map((value) => value.toString())
           .toList(),
+      proxyProfiles: (json['proxyProfiles'] as List? ?? const [])
+          .whereType<Map>()
+          .map((value) => ProxyProfile(Map<String, dynamic>.from(value)))
+          .toList(),
       extras: extras,
     );
   }
@@ -42,6 +48,7 @@ class VaultData {
   final List<SshKeyProfile> keys;
   final List<CommandSnippet> snippets;
   final List<String> customGroups;
+  final List<ProxyProfile> proxyProfiles;
   final Map<String, dynamic> extras;
 
   VaultData copyWith({
@@ -49,6 +56,7 @@ class VaultData {
     List<SshKeyProfile>? keys,
     List<CommandSnippet>? snippets,
     List<String>? customGroups,
+    List<ProxyProfile>? proxyProfiles,
     Map<String, dynamic>? extras,
   }) =>
       VaultData(
@@ -56,6 +64,7 @@ class VaultData {
         keys: keys ?? this.keys,
         snippets: snippets ?? this.snippets,
         customGroups: customGroups ?? this.customGroups,
+        proxyProfiles: proxyProfiles ?? this.proxyProfiles,
         extras: extras ?? this.extras,
       );
 
@@ -66,6 +75,8 @@ class VaultData {
       ..['hosts'] = hosts.map((value) => value.toJson()).toList()
       ..['keys'] = keys.map((value) => value.toJson()).toList()
       ..['snippets'] = snippets.map((value) => value.toJson()).toList()
-      ..['customGroups'] = customGroups;
+      ..['customGroups'] = customGroups
+      ..['proxyProfiles'] =
+          proxyProfiles.map((value) => value.toJson()).toList();
   }
 }

--- a/lib/infrastructure/ssh/connection_platform_service.dart
+++ b/lib/infrastructure/ssh/connection_platform_service.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/services.dart';
+
+class ConnectionPlatformService {
+  const ConnectionPlatformService._();
+
+  static const _channel = MethodChannel('app.netcatty.mobile/connection');
+
+  static Future<void> setActive(bool active) async {
+    try {
+      await _channel.invokeMethod<void>('setActive', {'active': active});
+    } on MissingPluginException {
+      // Desktop/test builds do not need a mobile keepalive service.
+    }
+  }
+
+  static Future<void> beginBackgroundGrace() async {
+    try {
+      await _channel.invokeMethod<void>('beginBackgroundGrace');
+    } on MissingPluginException {
+      // No-op outside iOS.
+    }
+  }
+
+  static Future<void> endBackgroundGrace() async {
+    try {
+      await _channel.invokeMethod<void>('endBackgroundGrace');
+    } on MissingPluginException {
+      // No-op outside iOS.
+    }
+  }
+}

--- a/lib/infrastructure/ssh/ssh_service.dart
+++ b/lib/infrastructure/ssh/ssh_service.dart
@@ -9,7 +9,10 @@ import 'package:xterm/xterm.dart';
 import '../../domain/models/host.dart';
 
 typedef HostKeyVerifier = Future<bool> Function(
-    String algorithm, String fingerprint);
+  HostProfile host,
+  String algorithm,
+  String fingerprint,
+);
 
 typedef KeyboardInteractiveHandler = Future<List<String>?> Function(
   String name,
@@ -19,49 +22,138 @@ typedef KeyboardInteractiveHandler = Future<List<String>?> Function(
 
 class ActiveTerminalSession {
   ActiveTerminalSession({
+    required this.id,
     required this.host,
     required this.terminal,
-    this.sshClient,
+    required this.verifyHostKey,
+    required this.keyboardInteractive,
+    this.sshClients = const [],
     this.sshSession,
     this.telnetSocket,
   });
 
+  final String id;
   final HostProfile host;
   final Terminal terminal;
-  final SSHClient? sshClient;
+  final HostKeyVerifier verifyHostKey;
+  final KeyboardInteractiveHandler? keyboardInteractive;
+  final List<SSHClient> sshClients;
   final SSHSession? sshSession;
   final Socket? telnetSocket;
+  bool connected = true;
+  bool closedByUser = false;
 
+  SSHClient? get sshClient => sshClients.isEmpty ? null : sshClients.last;
   bool get isSsh => sshClient != null;
+  Future<void> get done =>
+      sshSession?.done ?? telnetSocket?.done ?? Future.value();
 
   Future<void> close() async {
+    closedByUser = true;
+    connected = false;
     sshSession?.close();
-    sshClient?.close();
+    for (final client in sshClients.reversed) {
+      client.close();
+    }
     await telnetSocket?.close();
   }
 }
 
 class SshService {
   Future<ActiveTerminalSession> connect({
+    required String sessionId,
     required HostProfile host,
+    required List<HostProfile> hosts,
     required List<SshKeyProfile> keys,
+    required List<ProxyProfile> proxyProfiles,
     required HostKeyVerifier verifyHostKey,
     KeyboardInteractiveHandler? keyboardInteractive,
+    Terminal? terminal,
   }) async {
     if (host.protocol == HostProtocol.telnet) {
-      return _connectTelnet(host);
+      return _connectTelnet(
+        sessionId,
+        host,
+        verifyHostKey,
+        keyboardInteractive,
+        terminal,
+      );
     }
     if (host.protocol == HostProtocol.mosh) {
-      throw UnsupportedError('Mosh 需要平台原生 UDP 运行时；当前构建请先使用 SSH。');
+      throw UnsupportedError('Mosh 需要平台原生 UDP 运行时，当前版本尚未启用。');
     }
-    final socket = await SSHSocket.connect(
-      host.hostname,
-      host.port,
-      timeout: Duration(
-        seconds:
-            (host.data['sshTcpConnectTimeoutSeconds'] as num?)?.toInt() ?? 15,
-      ),
-    );
+
+    final chain = _resolveHostChain(host, hosts);
+    final route = [...chain, host];
+    final clients = <SSHClient>[];
+    SSHSocket? transport;
+    try {
+      for (var index = 0; index < route.length; index++) {
+        final current = route[index];
+        transport ??= await _openTransport(
+          current,
+          proxyProfiles,
+          timeout: _connectTimeout(current),
+        );
+        final client = _createClient(
+          transport,
+          current,
+          keys,
+          verifyHostKey,
+          keyboardInteractive,
+        );
+        clients.add(client);
+        if (index < route.length - 1) {
+          final next = route[index + 1];
+          transport = await client.forwardLocal(next.hostname, next.port);
+        }
+      }
+
+      final client = clients.last;
+      final session = await client.shell(
+        pty: const SSHPtyConfig(type: 'xterm-256color', width: 80, height: 24),
+        environment: _environment(host),
+      );
+      final output = terminal ?? Terminal(maxLines: 10000);
+      output.onOutput =
+          (value) => session.write(Uint8List.fromList(utf8.encode(value)));
+      output.onResize = (width, height, pixelWidth, pixelHeight) {
+        session.resizeTerminal(width, height, pixelWidth, pixelHeight);
+      };
+      session.stdout.listen(
+        (data) => output.write(utf8.decode(data, allowMalformed: true)),
+      );
+      session.stderr.listen(
+        (data) => output.write(utf8.decode(data, allowMalformed: true)),
+      );
+      final startup = host.startupCommand;
+      if (startup != null && startup.isNotEmpty) {
+        session.write(Uint8List.fromList(utf8.encode('$startup\n')));
+      }
+      return ActiveTerminalSession(
+        id: sessionId,
+        host: host,
+        terminal: output,
+        verifyHostKey: verifyHostKey,
+        keyboardInteractive: keyboardInteractive,
+        sshClients: clients,
+        sshSession: session,
+      );
+    } catch (_) {
+      for (final client in clients.reversed) {
+        client.close();
+      }
+      rethrow;
+    }
+  }
+
+  SSHClient _createClient(
+    SSHSocket socket,
+    HostProfile host,
+    List<SshKeyProfile> keys,
+    HostKeyVerifier verifyHostKey,
+    KeyboardInteractiveHandler? keyboardInteractive,
+  ) {
     final identity = keys.cast<SshKeyProfile?>().firstWhere(
           (value) => value?.id == host.identityFileId,
           orElse: () => null,
@@ -69,11 +161,15 @@ class SshService {
     final identities = identity == null || identity.privateKey.isEmpty
         ? null
         : SSHKeyPair.fromPem(identity.privateKey, identity.passphrase);
-    final client = SSHClient(
+    return SSHClient(
       socket,
       username: host.username,
-      identities: identities,
-      onPasswordRequest: host.password == null ? null : () => host.password,
+      identities:
+          host.authMethod == HostAuthMethod.password ? null : identities,
+      onPasswordRequest:
+          host.authMethod == HostAuthMethod.key || host.password == null
+              ? null
+              : () => host.password,
       onUserInfoRequest: (request) async {
         if (keyboardInteractive != null) {
           return keyboardInteractive(
@@ -95,55 +191,179 @@ class SshService {
         seconds:
             (host.data['sshAuthReadyTimeoutSeconds'] as num?)?.toInt() ?? 30,
       ),
-      onVerifyHostKey: (type, fingerprint) =>
-          verifyHostKey(type, utf8.decode(fingerprint)),
-    );
-    final environment = <String, String>{};
-    for (final value
-        in host.data['environmentVariables'] as List? ?? const []) {
-      if (value is Map && value['name'] != null) {
-        environment[value['name'].toString()] =
-            value['value']?.toString() ?? '';
-      }
-    }
-    final session = await client.shell(
-      pty: const SSHPtyConfig(type: 'xterm-256color', width: 80, height: 24),
-      environment: environment,
-    );
-    final terminal = Terminal(maxLines: 10000);
-    terminal.onOutput =
-        (value) => session.write(Uint8List.fromList(utf8.encode(value)));
-    terminal.onResize = (width, height, pixelWidth, pixelHeight) {
-      session.resizeTerminal(width, height, pixelWidth, pixelHeight);
-    };
-    session.stdout.listen(
-      (data) => terminal.write(utf8.decode(data, allowMalformed: true)),
-    );
-    session.stderr.listen(
-      (data) => terminal.write(utf8.decode(data, allowMalformed: true)),
-    );
-    unawaited(
-      session.done.then((_) => terminal.write('\r\n\x1b[33m连接已关闭\x1b[0m\r\n')),
-    );
-    final startup = host.startupCommand;
-    if (startup != null && startup.isNotEmpty) {
-      session.write(Uint8List.fromList(utf8.encode('$startup\n')));
-    }
-    return ActiveTerminalSession(
-      host: host,
-      terminal: terminal,
-      sshClient: client,
-      sshSession: session,
+      onVerifyHostKey: (type, fingerprint) => verifyHostKey(
+        host,
+        type,
+        utf8.decode(fingerprint),
+      ),
     );
   }
 
-  Future<ActiveTerminalSession> _connectTelnet(HostProfile host) async {
+  List<HostProfile> _resolveHostChain(
+    HostProfile target,
+    List<HostProfile> hosts,
+  ) {
+    final byId = {for (final host in hosts) host.id: host};
+    final seen = <String>{target.id};
+    final result = <HostProfile>[];
+    for (final id in target.hostChainIds) {
+      final jump = byId[id];
+      if (jump == null) throw StateError('找不到跳板机：$id');
+      if (!seen.add(jump.id)) throw StateError('跳板机链路存在循环');
+      if (jump.protocol != HostProtocol.ssh) {
+        throw StateError('跳板机必须使用 SSH：${jump.label}');
+      }
+      result.add(jump);
+    }
+    return result;
+  }
+
+  Duration _connectTimeout(HostProfile host) => Duration(
+        seconds:
+            (host.data['sshTcpConnectTimeoutSeconds'] as num?)?.toInt() ?? 15,
+      );
+
+  Map<String, String> _environment(HostProfile host) {
+    final result = <String, String>{};
+    for (final value
+        in host.data['environmentVariables'] as List? ?? const []) {
+      if (value is Map && value['name'] != null) {
+        result[value['name'].toString()] = value['value']?.toString() ?? '';
+      }
+    }
+    return result;
+  }
+
+  ProxyConfig? _effectiveProxy(
+    HostProfile host,
+    List<ProxyProfile> profiles,
+  ) {
+    final profileId = host.proxyProfileId;
+    if (profileId != null && profileId.isNotEmpty) {
+      for (final profile in profiles) {
+        if (profile.id == profileId) return profile.config;
+      }
+      throw StateError('找不到代理配置：$profileId');
+    }
+    return host.proxyConfig;
+  }
+
+  Future<SSHSocket> _openTransport(
+    HostProfile host,
+    List<ProxyProfile> profiles, {
+    required Duration timeout,
+  }) async {
+    final proxy = _effectiveProxy(host, profiles);
+    if (proxy == null || proxy.host.isEmpty || proxy.port <= 0) {
+      return SSHSocket.connect(host.hostname, host.port, timeout: timeout);
+    }
+    final socket =
+        await Socket.connect(proxy.host, proxy.port, timeout: timeout);
+    final cursor = _SocketCursor(socket);
+    try {
+      switch (proxy.type) {
+        case ProxyType.http:
+          await _connectHttpProxy(socket, cursor, proxy, host);
+        case ProxyType.socks5:
+          await _connectSocksProxy(socket, cursor, proxy, host);
+      }
+      return _ProxySshSocket(socket, cursor);
+    } catch (_) {
+      socket.destroy();
+      rethrow;
+    }
+  }
+
+  Future<void> _connectHttpProxy(
+    Socket socket,
+    _SocketCursor cursor,
+    ProxyConfig proxy,
+    HostProfile target,
+  ) async {
+    final authority = '${target.hostname}:${target.port}';
+    final auth = proxy.username?.isNotEmpty == true
+        ? 'Proxy-Authorization: Basic ${base64Encode(utf8.encode('${proxy.username}:${proxy.password ?? ''}'))}\r\n'
+        : '';
+    socket.write(
+      'CONNECT $authority HTTP/1.1\r\nHost: $authority\r\n$auth'
+      'Proxy-Connection: keep-alive\r\n\r\n',
+    );
+    await socket.flush();
+    final header = utf8.decode(
+      await cursor.readUntil(const [13, 10, 13, 10], maxLength: 32768),
+      allowMalformed: true,
+    );
+    final match = RegExp(r'^HTTP/\d(?:\.\d)?\s+(\d{3})').firstMatch(header);
+    if (match == null || match.group(1) != '200') {
+      throw SocketException('HTTP 代理连接失败：${header.split('\r\n').first}');
+    }
+  }
+
+  Future<void> _connectSocksProxy(
+    Socket socket,
+    _SocketCursor cursor,
+    ProxyConfig proxy,
+    HostProfile target,
+  ) async {
+    final hasAuth = proxy.username?.isNotEmpty == true;
+    socket.add(hasAuth ? [5, 2, 0, 2] : [5, 1, 0]);
+    await socket.flush();
+    final greeting = await cursor.readExact(2);
+    if (greeting[0] != 5 || greeting[1] == 255) {
+      throw const SocketException('SOCKS5 代理拒绝认证方式');
+    }
+    if (greeting[1] == 2) {
+      final user = utf8.encode(proxy.username ?? '');
+      final pass = utf8.encode(proxy.password ?? '');
+      if (user.length > 255 || pass.length > 255) {
+        throw const SocketException('SOCKS5 代理用户名或密码过长');
+      }
+      socket.add([1, user.length, ...user, pass.length, ...pass]);
+      await socket.flush();
+      final auth = await cursor.readExact(2);
+      if (auth[1] != 0) throw const SocketException('SOCKS5 代理认证失败');
+    } else if (greeting[1] != 0) {
+      throw const SocketException('SOCKS5 代理认证方式不受支持');
+    }
+    final domain = utf8.encode(target.hostname);
+    if (domain.length > 255) throw const SocketException('目标主机名过长');
+    socket.add([
+      5,
+      1,
+      0,
+      3,
+      domain.length,
+      ...domain,
+      target.port >> 8,
+      target.port & 0xff,
+    ]);
+    await socket.flush();
+    final reply = await cursor.readExact(4);
+    if (reply[0] != 5 || reply[1] != 0) {
+      throw SocketException('SOCKS5 代理连接失败，状态码 ${reply[1]}');
+    }
+    final addressLength = switch (reply[3]) {
+      1 => 4,
+      3 => (await cursor.readExact(1)).first,
+      4 => 16,
+      _ => throw const SocketException('SOCKS5 返回了未知地址类型'),
+    };
+    await cursor.readExact(addressLength + 2);
+  }
+
+  Future<ActiveTerminalSession> _connectTelnet(
+    String sessionId,
+    HostProfile host,
+    HostKeyVerifier verifyHostKey,
+    KeyboardInteractiveHandler? keyboardInteractive,
+    Terminal? existingTerminal,
+  ) async {
     final socket = await Socket.connect(
       host.hostname,
       host.port,
       timeout: const Duration(seconds: 15),
     );
-    final terminal = Terminal(maxLines: 10000);
+    final terminal = existingTerminal ?? Terminal(maxLines: 10000);
     terminal.onOutput = (value) => socket.add(utf8.encode(value));
     socket.listen((bytes) {
       final visible = <int>[];
@@ -160,9 +380,106 @@ class SshService {
       terminal.write(utf8.decode(visible, allowMalformed: true));
     });
     return ActiveTerminalSession(
+      id: sessionId,
       host: host,
       terminal: terminal,
+      verifyHostKey: verifyHostKey,
+      keyboardInteractive: keyboardInteractive,
       telnetSocket: socket,
     );
   }
+}
+
+class _SocketCursor {
+  _SocketCursor(Socket socket) : _iterator = StreamIterator(socket);
+
+  final StreamIterator<Uint8List> _iterator;
+  final List<int> _buffer = [];
+
+  Future<List<int>> readExact(int length) async {
+    await _fill(length);
+    final result = _buffer.sublist(0, length);
+    _buffer.removeRange(0, length);
+    return result;
+  }
+
+  Future<List<int>> readUntil(
+    List<int> marker, {
+    required int maxLength,
+  }) async {
+    while (true) {
+      final index = _indexOf(_buffer, marker);
+      if (index >= 0) {
+        final end = index + marker.length;
+        final result = _buffer.sublist(0, end);
+        _buffer.removeRange(0, end);
+        return result;
+      }
+      if (_buffer.length >= maxLength) {
+        throw const SocketException('代理响应头过长');
+      }
+      if (!await _iterator.moveNext()) {
+        throw const SocketException('代理在握手完成前关闭了连接');
+      }
+      _buffer.addAll(_iterator.current);
+    }
+  }
+
+  Future<void> _fill(int length) async {
+    while (_buffer.length < length) {
+      if (!await _iterator.moveNext()) {
+        throw const SocketException('代理在握手完成前关闭了连接');
+      }
+      _buffer.addAll(_iterator.current);
+    }
+  }
+
+  Stream<Uint8List> remainingStream() async* {
+    if (_buffer.isNotEmpty) {
+      yield Uint8List.fromList(_buffer);
+      _buffer.clear();
+    }
+    while (await _iterator.moveNext()) {
+      yield _iterator.current;
+    }
+  }
+
+  static int _indexOf(List<int> source, List<int> marker) {
+    for (var index = 0; index <= source.length - marker.length; index++) {
+      var matches = true;
+      for (var offset = 0; offset < marker.length; offset++) {
+        if (source[index + offset] != marker[offset]) {
+          matches = false;
+          break;
+        }
+      }
+      if (matches) return index;
+    }
+    return -1;
+  }
+}
+
+class _ProxySshSocket implements SSHSocket {
+  _ProxySshSocket(this._socket, this._cursor);
+
+  final Socket _socket;
+  final _SocketCursor _cursor;
+
+  @override
+  Stream<Uint8List> get stream => _cursor.remainingStream();
+
+  @override
+  StreamSink<List<int>> get sink => _socket;
+
+  @override
+  Future<void> get done => _socket.done;
+
+  @override
+  Future<void> close() async => _socket.close();
+
+  @override
+  void destroy() => _socket.destroy();
+
+  @override
+  Future<void> flush() => _socket.flush();
 }

--- a/lib/infrastructure/storage/vault_repository.dart
+++ b/lib/infrastructure/storage/vault_repository.dart
@@ -50,6 +50,15 @@ class VaultRepository {
         key: 'host.${host.id}.telnetPassword',
       );
       if (telnet != null) host.data['telnetPassword'] = telnet;
+      final proxyPassword = await _secureStorage.read(
+        key: 'host.${host.id}.proxyPassword',
+      );
+      if (proxyPassword != null && host.data['proxyConfig'] is Map) {
+        host.data['proxyConfig'] = {
+          ...Map<String, dynamic>.from(host.data['proxyConfig'] as Map),
+          'password': proxyPassword,
+        };
+      }
     }
     for (final key in vault.keys) {
       final privateKey = await _secureStorage.read(
@@ -60,6 +69,17 @@ class VaultRepository {
       );
       if (privateKey != null) key.data['privateKey'] = privateKey;
       if (passphrase != null) key.data['passphrase'] = passphrase;
+    }
+    for (final profile in vault.proxyProfiles) {
+      final password = await _secureStorage.read(
+        key: 'proxy.${profile.id}.password',
+      );
+      if (password != null && profile.data['config'] is Map) {
+        profile.data['config'] = {
+          ...Map<String, dynamic>.from(profile.data['config'] as Map),
+          'password': password,
+        };
+      }
     }
     return vault;
   }
@@ -72,11 +92,18 @@ class VaultRepository {
       );
       final hostIds = vault.hosts.map((value) => value.id).toSet();
       final keyIds = vault.keys.map((value) => value.id).toSet();
+      final proxyIds = vault.proxyProfiles.map((value) => value.id).toSet();
       for (final host in previous.hosts.where(
         (value) => !hostIds.contains(value.id),
       )) {
         await _secureStorage.delete(key: 'host.${host.id}.password');
         await _secureStorage.delete(key: 'host.${host.id}.telnetPassword');
+        await _secureStorage.delete(key: 'host.${host.id}.proxyPassword');
+      }
+      for (final proxy in previous.proxyProfiles.where(
+        (value) => !proxyIds.contains(value.id),
+      )) {
+        await _secureStorage.delete(key: 'proxy.${proxy.id}.password');
       }
       for (final key in previous.keys.where(
         (value) => !keyIds.contains(value.id),
@@ -94,12 +121,28 @@ class VaultRepository {
       );
       host.data.remove('password');
       host.data.remove('telnetPassword');
+      final proxy = host.proxyConfig;
+      await _writeSecret('host.${host.id}.proxyPassword', proxy?.password);
+      if (host.data['proxyConfig'] is Map) {
+        host.data['proxyConfig'] =
+            Map<String, dynamic>.from(host.data['proxyConfig'] as Map)
+              ..remove('password');
+      }
     }
     for (final key in sanitized.keys) {
       await _writeSecret('key.${key.id}.private', key.privateKey);
       await _writeSecret('key.${key.id}.passphrase', key.passphrase);
       key.data['privateKey'] = '';
       key.data.remove('passphrase');
+    }
+    for (final profile in sanitized.proxyProfiles) {
+      final config = profile.config;
+      await _writeSecret('proxy.${profile.id}.password', config?.password);
+      if (profile.data['config'] is Map) {
+        profile.data['config'] =
+            Map<String, dynamic>.from(profile.data['config'] as Map)
+              ..remove('password');
+      }
     }
     await _preferences.setString(_vaultKey, jsonEncode(sanitized.toJson()));
     _changes.add(vault);

--- a/lib/infrastructure/sync/cloud_sync_service.dart
+++ b/lib/infrastructure/sync/cloud_sync_service.dart
@@ -65,10 +65,28 @@ class CloudSyncService {
   }
 
   Future<({SyncConnection connection, String password})> _setup() async {
-    final connection = await repository.loadSyncConnection();
+    var connection = await repository.loadSyncConnection();
     final password = await repository.readMasterPassword();
     if (connection == null || password == null || password.isEmpty) {
       throw StateError('请先在设置中配置云同步与同步密码');
+    }
+    if (connection.type == SyncProviderType.githubGist) {
+      if (connection.secret?.isNotEmpty != true) {
+        throw StateError('请先登录 GitHub');
+      }
+      if (connection.resourceId?.isNotEmpty != true) {
+        final id = await _discoverGist(connection);
+        if (id != null) {
+          connection = SyncConnection(
+            type: connection.type,
+            endpoint: connection.endpoint,
+            username: connection.username,
+            secret: connection.secret,
+            resourceId: id,
+          );
+          await repository.saveSyncConnection(connection);
+        }
+      }
     }
     if (connection.type == SyncProviderType.webdav &&
         Uri.tryParse(connection.endpoint)?.scheme != 'https') {
@@ -117,6 +135,16 @@ class CloudSyncService {
     final gist = jsonDecode(response.body) as Map<String, dynamic>;
     final file = (gist['files'] as Map)['netcatty-vault.json'] as Map?;
     if (file == null) return null;
+    if (file['truncated'] == true && file['raw_url'] != null) {
+      final raw = await _client.get(
+        Uri.parse(file['raw_url'].toString()),
+        headers: _githubHeaders(connection),
+      );
+      if (raw.statusCode < 200 || raw.statusCode >= 300) {
+        throw StateError('Gist 大文件读取失败 (${raw.statusCode})');
+      }
+      return SyncedVaultFile.fromJson(_decodeJsonObject(raw.body));
+    }
     return SyncedVaultFile.fromJson(
       jsonDecode(file['content'] as String) as Map<String, dynamic>,
     );
@@ -141,6 +169,7 @@ class CloudSyncService {
     } else {
       final gistBody = jsonEncode({
         'description': 'Netcatty Encrypted Vault (DO NOT EDIT MANUALLY)',
+        'public': false,
         'files': {
           'netcatty-vault.json': {'content': body},
         },
@@ -198,6 +227,30 @@ class CloudSyncService {
         'authorization': 'Bearer ${connection.secret ?? ''}',
         'x-github-api-version': '2022-11-28',
       };
+
+  Future<String?> _discoverGist(SyncConnection connection) async {
+    for (var page = 1; page <= 10; page++) {
+      final response = await _client.get(
+        Uri.parse('https://api.github.com/gists?per_page=100&page=$page'),
+        headers: _githubHeaders(connection),
+      );
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw StateError('无法查找 Netcatty Gist (${response.statusCode})');
+      }
+      final values = jsonDecode(response.body) as List;
+      for (final value in values.whereType<Map>()) {
+        final files = value['files'];
+        final description = value['description']?.toString();
+        if ((files is Map && files.containsKey('netcatty-vault.json')) ||
+            description == 'Netcatty Encrypted Vault (DO NOT EDIT MANUALLY)') {
+          final id = value['id']?.toString();
+          if (id?.isNotEmpty == true) return id;
+        }
+      }
+      if (values.length < 100) break;
+    }
+    return null;
+  }
 
   Map<String, dynamic> _decodeJsonObject(String input) {
     final raw = input.trim();
@@ -261,11 +314,27 @@ class CloudSyncService {
     for (final item in local.snippets) {
       snippets[item.id] = item;
     }
+    final proxyProfiles = <String, ProxyProfile>{
+      for (final item in remote.proxyProfiles) item.id: item,
+    };
+    for (final item in local.proxyProfiles) {
+      final other = proxyProfiles[item.id];
+      final localUpdated = (item.data['updatedAt'] as num?)?.toInt() ??
+          (item.data['createdAt'] as num?)?.toInt() ??
+          0;
+      final remoteUpdated = (other?.data['updatedAt'] as num?)?.toInt() ??
+          (other?.data['createdAt'] as num?)?.toInt() ??
+          0;
+      if (other == null || localUpdated >= remoteUpdated) {
+        proxyProfiles[item.id] = item;
+      }
+    }
     return remote.copyWith(
       hosts: hosts.values.toList(),
       keys: keys.values.toList(),
       snippets: snippets.values.toList(),
       customGroups: {...remote.customGroups, ...local.customGroups}.toList(),
+      proxyProfiles: proxyProfiles.values.toList(),
     );
   }
 }

--- a/lib/infrastructure/sync/github_auth_service.dart
+++ b/lib/infrastructure/sync/github_auth_service.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class GitHubDeviceAuthorization {
+  const GitHubDeviceAuthorization({
+    required this.deviceCode,
+    required this.userCode,
+    required this.verificationUri,
+    required this.expiresAt,
+    required this.interval,
+  });
+
+  final String deviceCode;
+  final String userCode;
+  final Uri verificationUri;
+  final DateTime expiresAt;
+  final Duration interval;
+}
+
+class GitHubAuthService {
+  GitHubAuthService({http.Client? client}) : _client = client ?? http.Client();
+
+  static const clientId = String.fromEnvironment(
+    'GITHUB_OAUTH_CLIENT_ID',
+    defaultValue: 'Ov23lidR2u8OIkHW19nk',
+  );
+
+  final http.Client _client;
+
+  Future<GitHubDeviceAuthorization> start() async {
+    final response = await _client.post(
+      Uri.parse('https://github.com/login/device/code'),
+      headers: const {'accept': 'application/json'},
+      body: const {'client_id': clientId, 'scope': 'gist read:user'},
+    );
+    final json = _json(response);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError(
+          json['error_description']?.toString() ?? 'GitHub 授权启动失败');
+    }
+    return GitHubDeviceAuthorization(
+      deviceCode: json['device_code'].toString(),
+      userCode: json['user_code'].toString(),
+      verificationUri: Uri.parse(json['verification_uri'].toString()),
+      expiresAt: DateTime.now().add(
+        Duration(seconds: (json['expires_in'] as num).toInt()),
+      ),
+      interval: Duration(seconds: (json['interval'] as num?)?.toInt() ?? 5),
+    );
+  }
+
+  Future<String> poll(GitHubDeviceAuthorization authorization) async {
+    var interval = authorization.interval;
+    while (DateTime.now().isBefore(authorization.expiresAt)) {
+      await Future<void>.delayed(interval);
+      final response = await _client.post(
+        Uri.parse('https://github.com/login/oauth/access_token'),
+        headers: const {'accept': 'application/json'},
+        body: {
+          'client_id': clientId,
+          'device_code': authorization.deviceCode,
+          'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
+        },
+      );
+      final json = _json(response);
+      final token = json['access_token']?.toString();
+      if (token?.isNotEmpty == true) return token!;
+      switch (json['error']?.toString()) {
+        case 'authorization_pending':
+          continue;
+        case 'slow_down':
+          interval += const Duration(seconds: 5);
+          continue;
+        case 'expired_token':
+          throw StateError('GitHub 验证码已过期，请重新登录');
+        case 'access_denied':
+          throw StateError('GitHub 授权已取消');
+        case final String error when error.isNotEmpty:
+          throw StateError(
+            json['error_description']?.toString() ?? 'GitHub 授权失败：$error',
+          );
+      }
+    }
+    throw StateError('GitHub 验证码已过期，请重新登录');
+  }
+
+  Future<Map<String, dynamic>> currentUser(String token) async {
+    final response = await _client.get(
+      Uri.parse('https://api.github.com/user'),
+      headers: {
+        'accept': 'application/vnd.github+json',
+        'authorization': 'Bearer $token',
+        'x-github-api-version': '2022-11-28',
+      },
+    );
+    final json = _json(response);
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw StateError('GitHub 登录状态无效 (${response.statusCode})');
+    }
+    return json;
+  }
+
+  Map<String, dynamic> _json(http.Response response) {
+    final value = jsonDecode(response.body);
+    return value is Map
+        ? Map<String, dynamic>.from(value)
+        : <String, dynamic>{};
+  }
+}

--- a/lib/presentation/home_shell.dart
+++ b/lib/presentation/home_shell.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'screens/settings_screen.dart';
 import 'screens/sftp_screen.dart';
@@ -6,16 +7,12 @@ import 'screens/snippets_screen.dart';
 import 'screens/terminal_screen.dart';
 import 'screens/vault_screen.dart';
 
-class HomeShell extends StatefulWidget {
+final homeTabProvider = StateProvider<int>((ref) => 0);
+
+class HomeShell extends ConsumerWidget {
   const HomeShell({super.key});
 
-  @override
-  State<HomeShell> createState() => _HomeShellState();
-}
-
-class _HomeShellState extends State<HomeShell> {
-  var _index = 0;
-  final _pages = const [
+  static const _pages = [
     VaultScreen(),
     TerminalScreen(),
     SftpScreen(),
@@ -24,38 +21,42 @@ class _HomeShellState extends State<HomeShell> {
   ];
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-        body: IndexedStack(index: _index, children: _pages),
-        bottomNavigationBar: NavigationBar(
-          selectedIndex: _index,
-          onDestinationSelected: (value) => setState(() => _index = value),
-          destinations: const [
-            NavigationDestination(
-              icon: Icon(Icons.dns_outlined),
-              selectedIcon: Icon(Icons.dns),
-              label: '保险库',
-            ),
-            NavigationDestination(
-              icon: Icon(Icons.terminal_outlined),
-              selectedIcon: Icon(Icons.terminal),
-              label: '终端',
-            ),
-            NavigationDestination(
-              icon: Icon(Icons.folder_outlined),
-              selectedIcon: Icon(Icons.folder),
-              label: '文件',
-            ),
-            NavigationDestination(
-              icon: Icon(Icons.code_outlined),
-              selectedIcon: Icon(Icons.code),
-              label: '片段',
-            ),
-            NavigationDestination(
-              icon: Icon(Icons.settings_outlined),
-              selectedIcon: Icon(Icons.settings),
-              label: '设置',
-            ),
-          ],
-        ),
-      );
+  Widget build(BuildContext context, WidgetRef ref) {
+    final index = ref.watch(homeTabProvider);
+    return Scaffold(
+      body: IndexedStack(index: index, children: _pages),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: index,
+        onDestinationSelected: (value) =>
+            ref.read(homeTabProvider.notifier).state = value,
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.dns_outlined),
+            selectedIcon: Icon(Icons.dns),
+            label: '保险库',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.terminal_outlined),
+            selectedIcon: Icon(Icons.terminal),
+            label: '终端',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.folder_outlined),
+            selectedIcon: Icon(Icons.folder),
+            label: '文件',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.code_outlined),
+            selectedIcon: Icon(Icons.code),
+            label: '片段',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.settings_outlined),
+            selectedIcon: Icon(Icons.settings),
+            label: '设置',
+          ),
+        ],
+      ),
+    );
+  }
 }

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../application/settings_controller.dart';
 import '../../application/vault_controller.dart';
@@ -11,6 +14,7 @@ import '../../domain/models/settings.dart';
 import '../../domain/models/vault.dart';
 import '../../infrastructure/storage/vault_repository.dart';
 import '../../infrastructure/sync/cloud_sync_service.dart';
+import '../../infrastructure/sync/github_auth_service.dart';
 import '../widgets/keychain_sheet.dart';
 
 class SettingsScreen extends ConsumerStatefulWidget {
@@ -34,6 +38,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   var terminalFontSize = 14.0;
   var _loaded = false;
   var _busy = false;
+  String? _githubUser;
 
   @override
   void didChangeDependencies() {
@@ -58,6 +63,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     themeMode = settings.themeMode;
     terminalFontSize = settings.terminalFontSize;
     aiKey.text = await repository.readAiApiKey() ?? '';
+    _githubUser =
+        sync?.type == SyncProviderType.githubGist ? sync?.username : null;
     if (mounted) {
       setState(() => provider = sync?.type ?? SyncProviderType.webdav);
     }
@@ -173,19 +180,61 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                               const InputDecoration(labelText: '密码 / 应用密码'),
                         ),
                       ] else ...[
-                        TextField(
-                          controller: resourceId,
-                          decoration: const InputDecoration(
-                            labelText: 'Gist ID（首次可留空）',
+                        ListTile(
+                          contentPadding: EdgeInsets.zero,
+                          leading: CircleAvatar(
+                            child: Icon(
+                              providerSecret.text.isEmpty
+                                  ? Icons.login
+                                  : Icons.check,
+                            ),
+                          ),
+                          title: Text(
+                            providerSecret.text.isEmpty
+                                ? '尚未登录 GitHub'
+                                : '已连接 GitHub',
+                          ),
+                          subtitle: Text(
+                            _githubUser == null
+                                ? '登录后自动查找或创建 Netcatty Gist'
+                                : '@$_githubUser · 自动同步私有 Gist',
                           ),
                         ),
-                        const SizedBox(height: 10),
-                        TextField(
-                          controller: providerSecret,
-                          obscureText: true,
-                          decoration: const InputDecoration(
-                            labelText: 'GitHub Token（gist 权限）',
-                          ),
+                        SizedBox(
+                          width: double.infinity,
+                          child: providerSecret.text.isEmpty
+                              ? FilledButton.icon(
+                                  onPressed: _busy ? null : _connectGitHub,
+                                  icon: const Icon(Icons.login),
+                                  label: const Text('登录 GitHub'),
+                                )
+                              : OutlinedButton.icon(
+                                  onPressed: _busy ? null : _logoutGitHub,
+                                  icon: const Icon(Icons.logout),
+                                  label: const Text('退出 GitHub'),
+                                ),
+                        ),
+                        ExpansionTile(
+                          tilePadding: EdgeInsets.zero,
+                          title: const Text('高级 / 手动配置'),
+                          subtitle: const Text('仅用于迁移或登录故障排查'),
+                          children: [
+                            TextField(
+                              controller: resourceId,
+                              decoration: const InputDecoration(
+                                labelText: 'Gist ID（通常自动识别）',
+                              ),
+                            ),
+                            const SizedBox(height: 10),
+                            TextField(
+                              controller: providerSecret,
+                              obscureText: true,
+                              onChanged: (_) => setState(() {}),
+                              decoration: const InputDecoration(
+                                labelText: 'GitHub Token（备用）',
+                              ),
+                            ),
+                          ],
                         ),
                       ],
                       const SizedBox(height: 10),
@@ -340,13 +389,54 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
     final connection = SyncConnection(
       type: provider,
       endpoint: endpoint.text.trim(),
-      username: username.text.trim(),
+      // GitHub 用户名仅用于展示，不参与 API 认证。
+      username: provider == SyncProviderType.githubGist
+          ? _githubUser
+          : username.text.trim(),
       secret: providerSecret.text,
       resourceId: resourceId.text.trim(),
     );
     final repository = ref.read(vaultRepositoryProvider);
     await repository.saveSyncConnection(connection);
     await repository.saveMasterPassword(masterPassword.text);
+  }
+
+  Future<void> _connectGitHub() async {
+    setState(() => _busy = true);
+    try {
+      final auth = GitHubAuthService();
+      final authorization = await auth.start();
+      if (!mounted) return;
+      final token = await showDialog<String>(
+        context: context,
+        barrierDismissible: false,
+        builder: (_) => _GitHubDeviceFlowDialog(
+          authorization: authorization,
+          tokenFuture: auth.poll(authorization),
+        ),
+      );
+      if (token == null || !mounted) return;
+      final user = await auth.currentUser(token);
+      providerSecret.text = token;
+      resourceId.clear();
+      _githubUser = user['login']?.toString();
+      await _saveSync();
+      if (mounted) setState(() {});
+      _message('GitHub 登录成功，将自动查找 Netcatty Gist');
+    } catch (error) {
+      _message('$error');
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _logoutGitHub() async {
+    providerSecret.clear();
+    resourceId.clear();
+    _githubUser = null;
+    await _saveSync();
+    if (mounted) setState(() {});
+    _message('已退出 GitHub');
   }
 
   Future<void> _sync({required bool push}) async {
@@ -437,4 +527,89 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
       ).showSnackBar(SnackBar(content: Text(value)));
     }
   }
+}
+
+class _GitHubDeviceFlowDialog extends StatefulWidget {
+  const _GitHubDeviceFlowDialog({
+    required this.authorization,
+    required this.tokenFuture,
+  });
+
+  final GitHubDeviceAuthorization authorization;
+  final Future<String> tokenFuture;
+
+  @override
+  State<_GitHubDeviceFlowDialog> createState() =>
+      _GitHubDeviceFlowDialogState();
+}
+
+class _GitHubDeviceFlowDialogState extends State<_GitHubDeviceFlowDialog> {
+  Object? error;
+
+  @override
+  void initState() {
+    super.initState();
+    unawaited(Clipboard.setData(
+      ClipboardData(text: widget.authorization.userCode),
+    ));
+    unawaited(_openGitHub());
+    widget.tokenFuture.then((token) {
+      if (mounted) Navigator.pop(context, token);
+    }).catchError((Object value) {
+      if (mounted) setState(() => error = value);
+    });
+  }
+
+  Future<void> _openGitHub() => launchUrl(
+        widget.authorization.verificationUri,
+        mode: LaunchMode.externalApplication,
+      );
+
+  @override
+  Widget build(BuildContext context) => AlertDialog(
+        icon: const Icon(Icons.code, size: 34),
+        title: const Text('登录 GitHub'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('验证码已复制。请在浏览器中登录 GitHub 并确认授权。'),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 22, vertical: 14),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: SelectableText(
+                widget.authorization.userCode,
+                style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+                      letterSpacing: 3,
+                      fontWeight: FontWeight.bold,
+                    ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            if (error == null) ...[
+              const LinearProgressIndicator(),
+              const SizedBox(height: 8),
+              const Text('正在等待 GitHub 授权…'),
+            ] else
+              Text(
+                '$error',
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('取消'),
+          ),
+          OutlinedButton.icon(
+            onPressed: _openGitHub,
+            icon: const Icon(Icons.open_in_browser),
+            label: const Text('打开 GitHub'),
+          ),
+        ],
+      );
 }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4,6 +4,7 @@ import 'package:xterm/xterm.dart';
 
 import '../../application/session_controller.dart';
 import '../../application/settings_controller.dart';
+import '../../domain/models/settings.dart';
 import '../../infrastructure/ai/ai_service.dart';
 import '../../infrastructure/ssh/ssh_service.dart';
 import '../../infrastructure/storage/vault_repository.dart';
@@ -41,22 +42,47 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
                       : ListView.builder(
                           scrollDirection: Axis.horizontal,
                           itemCount: state.sessions.length,
-                          itemBuilder: (_, index) => Padding(
-                            padding: const EdgeInsets.symmetric(
-                              vertical: 7,
-                              horizontal: 2,
-                            ),
-                            child: InputChip(
-                              selected: state.activeIndex == index,
-                              label: Text(state.sessions[index].host.label),
-                              onPressed: () => ref
-                                  .read(sessionControllerProvider.notifier)
-                                  .activate(index),
-                              onDeleted: () => ref
-                                  .read(sessionControllerProvider.notifier)
-                                  .close(index),
-                            ),
-                          ),
+                          itemBuilder: (_, index) {
+                            final session = state.sessions[index];
+                            final occurrence = state.sessions
+                                .take(index + 1)
+                                .where(
+                                    (value) => value.host.id == session.host.id)
+                                .length;
+                            final duplicateCount = state.sessions
+                                .where(
+                                    (value) => value.host.id == session.host.id)
+                                .length;
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(
+                                vertical: 7,
+                                horizontal: 2,
+                              ),
+                              child: InputChip(
+                                selected: state.activeIndex == index,
+                                avatar: Icon(
+                                  session.connected
+                                      ? Icons.circle
+                                      : Icons.error_outline,
+                                  size: session.connected ? 10 : 16,
+                                  color: session.connected
+                                      ? Colors.greenAccent
+                                      : Colors.orangeAccent,
+                                ),
+                                label: Text(
+                                  duplicateCount > 1
+                                      ? '${session.host.label} #$occurrence'
+                                      : session.host.label,
+                                ),
+                                onPressed: () => ref
+                                    .read(sessionControllerProvider.notifier)
+                                    .activate(index),
+                                onDeleted: () => ref
+                                    .read(sessionControllerProvider.notifier)
+                                    .close(index),
+                              ),
+                            );
+                          },
                         ),
                 ),
                 if (state.sessions.length > 1)
@@ -139,6 +165,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
           ),
           if (state.active != null)
             _SpecialKeys(
+              order: settings.terminalQuickKeys,
               onSend: ref.read(sessionControllerProvider.notifier).send,
             ),
         ],
@@ -273,41 +300,153 @@ class _TerminalPane extends StatelessWidget {
       );
 }
 
-class _SpecialKeys extends StatelessWidget {
-  const _SpecialKeys({required this.onSend});
+class _SpecialKeys extends ConsumerWidget {
+  const _SpecialKeys({required this.order, required this.onSend});
+  final List<String> order;
   final void Function(String, {bool enter}) onSend;
 
   @override
-  Widget build(BuildContext context) => SizedBox(
-        height: 44,
-        child: ListView(
-          scrollDirection: Axis.horizontal,
-          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
-          children: [
-            _key('Esc', '\x1b'),
-            _key('Tab', '\t'),
-            _key('Ctrl+C', '\x03'),
-            _key('Ctrl+D', '\x04'),
-            _key('Ctrl+Z', '\x1a'),
-            _key('↑', '\x1b[A'),
-            _key('↓', '\x1b[B'),
-            _key('←', '\x1b[D'),
-            _key('→', '\x1b[C'),
-            _key('|', '|'),
-            _key('/', '/'),
-            _key('~', '~'),
-          ],
-        ),
+  Widget build(BuildContext context, WidgetRef ref) {
+    final normalized = [
+      ...order.where(_quickKeys.containsKey),
+      ...defaultTerminalQuickKeys.where((value) => !order.contains(value)),
+    ];
+    final split = (normalized.length + 1) ~/ 2;
+    return SizedBox(
+      height: 92,
+      child: Row(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 6),
+            child: IconButton(
+              tooltip: '自定义快捷键顺序',
+              onPressed: () => _customize(context, ref, normalized),
+              icon: const Icon(Icons.tune, size: 20),
+            ),
+          ),
+          Expanded(
+            child: Column(
+              children: [
+                Expanded(child: _row(normalized.take(split))),
+                Expanded(child: _row(normalized.skip(split))),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _row(Iterable<String> ids) => ListView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 3),
+        children: ids.map((id) {
+          final key = _quickKeys[id]!;
+          return _key(key.label, key.value);
+        }).toList(),
       );
 
-  Widget _key(String label, String value) => Padding(
+  Widget _key(String label, String? value) => Padding(
         padding: const EdgeInsets.only(right: 6),
         child: OutlinedButton(
-          onPressed: () => onSend(value),
+          onPressed: value == null
+              ? () => FocusManager.instance.primaryFocus?.unfocus()
+              : () => onSend(value),
           style: OutlinedButton.styleFrom(
             padding: const EdgeInsets.symmetric(horizontal: 12),
           ),
           child: Text(label),
         ),
       );
+
+  Future<void> _customize(
+    BuildContext context,
+    WidgetRef ref,
+    List<String> current,
+  ) async {
+    final working = [...current];
+    final result = await showModalBottomSheet<List<String>>(
+      context: context,
+      useSafeArea: true,
+      isScrollControlled: true,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setModalState) => SizedBox(
+          height: MediaQuery.sizeOf(context).height * .72,
+          child: Column(
+            children: [
+              ListTile(
+                title: const Text('快捷键顺序'),
+                subtitle: const Text('拖动排序，终端中会自动分成两行显示'),
+                trailing: TextButton(
+                  onPressed: () => setModalState(() {
+                    working
+                      ..clear()
+                      ..addAll(defaultTerminalQuickKeys);
+                  }),
+                  child: const Text('恢复默认'),
+                ),
+              ),
+              const Divider(height: 1),
+              Expanded(
+                child: ReorderableListView.builder(
+                  itemCount: working.length,
+                  onReorderItem: (oldIndex, newIndex) => setModalState(() {
+                    final value = working.removeAt(oldIndex);
+                    working.insert(newIndex, value);
+                  }),
+                  itemBuilder: (context, index) {
+                    final id = working[index];
+                    return ListTile(
+                      key: ValueKey(id),
+                      leading: const Icon(Icons.drag_handle),
+                      title: Text(_quickKeys[id]!.label),
+                      trailing: Text(
+                          index < (working.length + 1) ~/ 2 ? '第一行' : '第二行'),
+                    );
+                  },
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: SizedBox(
+                  width: double.infinity,
+                  child: FilledButton(
+                    onPressed: () => Navigator.pop(context, working),
+                    child: const Text('保存排序'),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+    if (result == null) return;
+    final settings = ref.read(settingsControllerProvider);
+    await ref.read(settingsControllerProvider.notifier).update(
+          settings.copyWith(terminalQuickKeys: result),
+        );
+  }
 }
+
+class _QuickKey {
+  const _QuickKey(this.label, this.value);
+  final String label;
+  final String? value;
+}
+
+const _quickKeys = <String, _QuickKey>{
+  'escape': _QuickKey('Esc', '\x1b'),
+  'tab': _QuickKey('Tab', '\t'),
+  'ctrlC': _QuickKey('Ctrl+C', '\x03'),
+  'ctrlD': _QuickKey('Ctrl+D', '\x04'),
+  'ctrlZ': _QuickKey('Ctrl+Z', '\x1a'),
+  'arrowUp': _QuickKey('↑', '\x1b[A'),
+  'arrowDown': _QuickKey('↓', '\x1b[B'),
+  'arrowLeft': _QuickKey('←', '\x1b[D'),
+  'arrowRight': _QuickKey('→', '\x1b[C'),
+  'pipe': _QuickKey('|', '|'),
+  'slash': _QuickKey('/', '/'),
+  'tilde': _QuickKey('~', '~'),
+  'hideKeyboard': _QuickKey('收起键盘', null),
+};

--- a/lib/presentation/screens/vault_screen.dart
+++ b/lib/presentation/screens/vault_screen.dart
@@ -5,8 +5,10 @@ import 'package:uuid/uuid.dart';
 import '../../application/session_controller.dart';
 import '../../application/vault_controller.dart';
 import '../../domain/models/host.dart';
+import '../home_shell.dart';
 import '../theme.dart';
 import '../widgets/empty_state.dart';
+import '../widgets/host_editor.dart';
 
 class VaultScreen extends ConsumerStatefulWidget {
   const VaultScreen({super.key});
@@ -137,7 +139,8 @@ class _VaultScreenState extends ConsumerState<VaultScreen> {
                                 itemCount: hosts.length,
                                 itemBuilder: (_, index) => _HostCard(
                                   host: hosts[index],
-                                  onConnect: () => _connect(hosts[index]),
+                                  onConnect: () =>
+                                      _showHostDetails(hosts[index]),
                                   onEdit: () => _editHost(hosts[index]),
                                 ),
                               )
@@ -148,7 +151,8 @@ class _VaultScreenState extends ConsumerState<VaultScreen> {
                                     const SizedBox(height: 8),
                                 itemBuilder: (_, index) => _HostTile(
                                   host: hosts[index],
-                                  onConnect: () => _connect(hosts[index]),
+                                  onConnect: () =>
+                                      _showHostDetails(hosts[index]),
                                   onEdit: () => _editHost(hosts[index]),
                                 ),
                               ),
@@ -163,11 +167,11 @@ class _VaultScreenState extends ConsumerState<VaultScreen> {
     try {
       await ref.read(sessionControllerProvider.notifier).connect(
             host,
-            (algorithm, fingerprint) =>
-                _verifyHostKey(host, algorithm, fingerprint),
+            _verifyHostKey,
             keyboardInteractive: _promptKeyboardInteractive,
           );
       if (mounted) {
+        ref.read(homeTabProvider.notifier).state = 1;
         ScaffoldMessenger.of(
           context,
         ).showSnackBar(const SnackBar(content: Text('已连接，请打开“终端”标签')));
@@ -178,6 +182,97 @@ class _VaultScreenState extends ConsumerState<VaultScreen> {
           context,
         ).showSnackBar(SnackBar(content: Text('连接失败：$error')));
       }
+    }
+  }
+
+  Future<void> _showHostDetails(HostProfile host) async {
+    final vault = ref.read(vaultControllerProvider).data;
+    final key = vault?.keys.cast<SshKeyProfile?>().firstWhere(
+          (value) => value?.id == host.identityFileId,
+          orElse: () => null,
+        );
+    final jumps = host.hostChainIds
+        .map((id) => vault?.hosts.cast<HostProfile?>().firstWhere(
+              (value) => value?.id == id,
+              orElse: () => null,
+            ))
+        .whereType<HostProfile>()
+        .toList();
+    final profile = vault?.proxyProfiles.cast<ProxyProfile?>().firstWhere(
+          (value) => value?.id == host.proxyProfileId,
+          orElse: () => null,
+        );
+    final proxy = profile?.config ?? host.proxyConfig;
+    final action = await showDialog<_HostAction>(
+      context: context,
+      builder: (context) => AlertDialog(
+        icon: const Icon(Icons.dns_outlined, color: NetcattyTheme.accent),
+        title: Text(host.label),
+        content: SizedBox(
+          width: 440,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _DetailRow(
+                icon: Icons.link,
+                label: '连接地址',
+                value:
+                    '${host.protocol.name.toUpperCase()}  ${host.username}@${host.hostname}:${host.port}',
+              ),
+              _DetailRow(
+                icon: Icons.key_outlined,
+                label: '认证',
+                value: key == null
+                    ? (host.password?.isNotEmpty == true ? '密码' : '自动 / 交互式')
+                    : '私钥 · ${key.label}',
+              ),
+              if (jumps.isNotEmpty)
+                _DetailRow(
+                  icon: Icons.alt_route,
+                  label: '跳板机',
+                  value: jumps.map((value) => value.label).join(' → '),
+                ),
+              if (proxy != null)
+                _DetailRow(
+                  icon: Icons.public,
+                  label: '代理',
+                  value:
+                      '${proxy.type.name.toUpperCase()} · ${proxy.host}:${proxy.port}',
+                ),
+              if (host.group?.isNotEmpty == true)
+                _DetailRow(
+                  icon: Icons.folder_outlined,
+                  label: '分组',
+                  value: host.group!,
+                ),
+              if (host.tags.isNotEmpty)
+                _DetailRow(
+                  icon: Icons.sell_outlined,
+                  label: '标签',
+                  value: host.tags.join('、'),
+                ),
+            ],
+          ),
+        ),
+        actions: [
+          TextButton.icon(
+            onPressed: () => Navigator.pop(context, _HostAction.edit),
+            icon: const Icon(Icons.edit_outlined),
+            label: const Text('编辑'),
+          ),
+          FilledButton.icon(
+            onPressed: () => Navigator.pop(context, _HostAction.connect),
+            icon: const Icon(Icons.terminal),
+            label: const Text('连接'),
+          ),
+        ],
+      ),
+    );
+    if (!mounted) return;
+    if (action == _HostAction.edit) {
+      await _editHost(host);
+    } else if (action == _HostAction.connect) {
+      await _connect(host);
     }
   }
 
@@ -413,15 +508,49 @@ class _HostTile extends StatelessWidget {
       );
 }
 
-class HostEditor extends StatefulWidget {
-  const HostEditor({super.key, this.host});
+enum _HostAction { connect, edit }
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: 7),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(icon, size: 19, color: NetcattyTheme.accent),
+            const SizedBox(width: 12),
+            SizedBox(
+              width: 62,
+              child: Text(
+                label,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+            Expanded(child: SelectableText(value)),
+          ],
+        ),
+      );
+}
+
+class _LegacyHostEditor extends StatefulWidget {
+  const _LegacyHostEditor({required this.host});
   final HostProfile? host;
 
   @override
-  State<HostEditor> createState() => _HostEditorState();
+  State<_LegacyHostEditor> createState() => _LegacyHostEditorState();
 }
 
-class _HostEditorState extends State<HostEditor> {
+class _LegacyHostEditorState extends State<_LegacyHostEditor> {
   final _form = GlobalKey<FormState>();
   late final TextEditingController label;
   late final TextEditingController hostname;

--- a/lib/presentation/widgets/host_editor.dart
+++ b/lib/presentation/widgets/host_editor.dart
@@ -1,0 +1,590 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:uuid/uuid.dart';
+
+import '../../application/vault_controller.dart';
+import '../../domain/models/host.dart';
+import 'keychain_sheet.dart';
+
+class HostEditor extends ConsumerStatefulWidget {
+  const HostEditor({super.key, this.host});
+
+  final HostProfile? host;
+
+  @override
+  ConsumerState<HostEditor> createState() => _HostEditorState();
+}
+
+class _HostEditorState extends ConsumerState<HostEditor> {
+  final _form = GlobalKey<FormState>();
+  late final TextEditingController label;
+  late final TextEditingController hostname;
+  late final TextEditingController username;
+  late final TextEditingController port;
+  late final TextEditingController password;
+  late final TextEditingController group;
+  late final TextEditingController tags;
+  late final TextEditingController startupCommand;
+  late final TextEditingController proxyHost;
+  late final TextEditingController proxyPort;
+  late final TextEditingController proxyUsername;
+  late final TextEditingController proxyPassword;
+  late final TextEditingController keepalive;
+  late final TextEditingController connectTimeout;
+  late final TextEditingController authTimeout;
+  late HostProtocol protocol;
+  late HostAuthMethod authMethod;
+  late ProxyType proxyType;
+  late List<String> jumpHostIds;
+  String? identityFileId;
+  String proxyMode = 'none';
+  bool obscurePassword = true;
+  bool obscureProxyPassword = true;
+  bool pinned = false;
+
+  @override
+  void initState() {
+    super.initState();
+    final host = widget.host;
+    final proxy = host?.proxyConfig;
+    label = TextEditingController(text: host?.label);
+    hostname = TextEditingController(text: host?.hostname);
+    username = TextEditingController(text: host?.username);
+    port = TextEditingController(text: (host?.port ?? 22).toString());
+    password = TextEditingController(text: host?.password);
+    group = TextEditingController(text: host?.group);
+    tags = TextEditingController(text: host?.tags.join(', '));
+    startupCommand = TextEditingController(text: host?.startupCommand);
+    proxyHost = TextEditingController(text: proxy?.host);
+    proxyPort = TextEditingController(
+      text: proxy == null || proxy.port == 0 ? '' : proxy.port.toString(),
+    );
+    proxyUsername = TextEditingController(text: proxy?.username);
+    proxyPassword = TextEditingController(text: proxy?.password);
+    keepalive = TextEditingController(
+      text:
+          ((host?.data['keepaliveInterval'] as num?)?.toInt() ?? 10).toString(),
+    );
+    connectTimeout = TextEditingController(
+      text: ((host?.data['sshTcpConnectTimeoutSeconds'] as num?)?.toInt() ?? 15)
+          .toString(),
+    );
+    authTimeout = TextEditingController(
+      text: ((host?.data['sshAuthReadyTimeoutSeconds'] as num?)?.toInt() ?? 30)
+          .toString(),
+    );
+    protocol = host?.protocol ?? HostProtocol.ssh;
+    authMethod = host?.authMethod ?? HostAuthMethod.auto;
+    identityFileId = host?.identityFileId;
+    jumpHostIds = [...?host?.hostChainIds];
+    proxyType = proxy?.type ?? ProxyType.http;
+    proxyMode = host?.proxyProfileId?.isNotEmpty == true
+        ? 'profile:${host!.proxyProfileId}'
+        : proxy == null
+            ? 'none'
+            : 'custom';
+    pinned = host?.pinned ?? false;
+  }
+
+  @override
+  void dispose() {
+    for (final controller in [
+      label,
+      hostname,
+      username,
+      port,
+      password,
+      group,
+      tags,
+      startupCommand,
+      proxyHost,
+      proxyPort,
+      proxyUsername,
+      proxyPassword,
+      keepalive,
+      connectTimeout,
+      authTimeout,
+    ]) {
+      controller.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final vault = ref.watch(vaultControllerProvider).data;
+    final keys = vault?.keys ?? const <SshKeyProfile>[];
+    final availableHosts = (vault?.hosts ?? const <HostProfile>[])
+        .where((value) =>
+            value.id != widget.host?.id &&
+            value.protocol == HostProtocol.ssh &&
+            !jumpHostIds.contains(value.id))
+        .toList();
+    final profiles = vault?.proxyProfiles ?? const <ProxyProfile>[];
+    if (identityFileId != null &&
+        !keys.any((value) => value.id == identityFileId)) {
+      identityFileId = null;
+    }
+    if (proxyMode.startsWith('profile:') &&
+        !profiles.any((value) => 'profile:${value.id}' == proxyMode)) {
+      proxyMode = 'none';
+    }
+
+    return Padding(
+      padding: EdgeInsets.only(bottom: MediaQuery.viewInsetsOf(context).bottom),
+      child: Scaffold(
+        appBar: AppBar(
+          leading: IconButton(
+            onPressed: () => Navigator.pop(context),
+            icon: const Icon(Icons.close),
+          ),
+          title: Text(widget.host == null ? '新建连接' : '编辑连接'),
+          actions: [TextButton(onPressed: _save, child: const Text('保存'))],
+        ),
+        body: Form(
+          key: _form,
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+            children: [
+              SegmentedButton<HostProtocol>(
+                segments: const [
+                  ButtonSegment(
+                    value: HostProtocol.ssh,
+                    label: Text('SSH'),
+                    icon: Icon(Icons.lock_outline),
+                  ),
+                  ButtonSegment(
+                    value: HostProtocol.telnet,
+                    label: Text('Telnet'),
+                    icon: Icon(Icons.cable),
+                  ),
+                  ButtonSegment(
+                    value: HostProtocol.mosh,
+                    label: Text('Mosh'),
+                    icon: Icon(Icons.wifi_tethering),
+                  ),
+                ],
+                selected: {protocol},
+                onSelectionChanged: (value) => setState(() {
+                  protocol = value.first;
+                  if (port.text == '22' || port.text == '23') {
+                    port.text = protocol == HostProtocol.telnet ? '23' : '22';
+                  }
+                }),
+              ),
+              _section('基本信息'),
+              TextFormField(
+                controller: label,
+                decoration: const InputDecoration(labelText: '名称'),
+                validator: _required,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: hostname,
+                decoration: const InputDecoration(labelText: '主机名 / IP'),
+                keyboardType: TextInputType.url,
+                validator: _required,
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    flex: 2,
+                    child: TextFormField(
+                      controller: username,
+                      decoration: const InputDecoration(labelText: '用户名'),
+                      validator: _required,
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: TextFormField(
+                      controller: port,
+                      decoration: const InputDecoration(labelText: '端口'),
+                      keyboardType: TextInputType.number,
+                      validator: _validPort,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: group,
+                decoration: const InputDecoration(labelText: '分组（可选）'),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: tags,
+                decoration: const InputDecoration(
+                  labelText: '标签（逗号分隔）',
+                ),
+              ),
+              SwitchListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('置顶显示'),
+                value: pinned,
+                onChanged: (value) => setState(() => pinned = value),
+              ),
+              if (protocol != HostProtocol.telnet) ...[
+                _section('身份认证'),
+                DropdownButtonFormField<HostAuthMethod>(
+                  initialValue: authMethod,
+                  decoration: const InputDecoration(labelText: '认证方式'),
+                  items: const [
+                    DropdownMenuItem(
+                      value: HostAuthMethod.auto,
+                      child: Text('自动（私钥 / 密码 / 交互式）'),
+                    ),
+                    DropdownMenuItem(
+                      value: HostAuthMethod.password,
+                      child: Text('密码'),
+                    ),
+                    DropdownMenuItem(
+                      value: HostAuthMethod.key,
+                      child: Text('私钥'),
+                    ),
+                  ],
+                  onChanged: (value) =>
+                      setState(() => authMethod = value ?? HostAuthMethod.auto),
+                ),
+                const SizedBox(height: 12),
+                TextFormField(
+                  controller: password,
+                  obscureText: obscurePassword,
+                  decoration: InputDecoration(
+                    labelText: '密码（可选）',
+                    suffixIcon: IconButton(
+                      onPressed: () =>
+                          setState(() => obscurePassword = !obscurePassword),
+                      icon: Icon(
+                        obscurePassword
+                            ? Icons.visibility
+                            : Icons.visibility_off,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    Expanded(
+                      child: DropdownButtonFormField<String>(
+                        initialValue: identityFileId,
+                        decoration: const InputDecoration(labelText: 'SSH 私钥'),
+                        items: [
+                          const DropdownMenuItem(
+                            value: '',
+                            child: Text('不指定'),
+                          ),
+                          for (final key in keys)
+                            DropdownMenuItem(
+                              value: key.id,
+                              child: Text(key.label),
+                            ),
+                        ],
+                        onChanged: (value) => setState(
+                          () => identityFileId =
+                              value?.isEmpty == true ? null : value,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    IconButton.filledTonal(
+                      tooltip: '管理私钥',
+                      onPressed: _openKeychain,
+                      icon: const Icon(Icons.key_outlined),
+                    ),
+                  ],
+                ),
+                if (authMethod == HostAuthMethod.key && identityFileId == null)
+                  const Padding(
+                    padding: EdgeInsets.only(top: 6),
+                    child: Text(
+                      '私钥认证需要选择或导入私钥。',
+                      style: TextStyle(color: Colors.redAccent, fontSize: 12),
+                    ),
+                  ),
+                _section('跳板机'),
+                if (jumpHostIds.isEmpty)
+                  const ListTile(
+                    contentPadding: EdgeInsets.zero,
+                    leading: Icon(Icons.alt_route),
+                    title: Text('直接连接'),
+                    subtitle: Text('未设置 SSH 跳板机'),
+                  )
+                else
+                  ReorderableListView.builder(
+                    shrinkWrap: true,
+                    physics: const NeverScrollableScrollPhysics(),
+                    itemCount: jumpHostIds.length,
+                    onReorderItem: (oldIndex, newIndex) => setState(() {
+                      final id = jumpHostIds.removeAt(oldIndex);
+                      jumpHostIds.insert(newIndex, id);
+                    }),
+                    itemBuilder: (context, index) {
+                      final id = jumpHostIds[index];
+                      final jump = vault?.hosts.cast<HostProfile?>().firstWhere(
+                            (value) => value?.id == id,
+                            orElse: () => null,
+                          );
+                      return ListTile(
+                        key: ValueKey(id),
+                        contentPadding: EdgeInsets.zero,
+                        leading: CircleAvatar(child: Text('${index + 1}')),
+                        title: Text(jump?.label ?? '缺失的主机'),
+                        subtitle: jump == null
+                            ? Text(id)
+                            : Text(
+                                '${jump.username}@${jump.hostname}:${jump.port}'),
+                        trailing: IconButton(
+                          onPressed: () =>
+                              setState(() => jumpHostIds.removeAt(index)),
+                          icon: const Icon(Icons.remove_circle_outline),
+                        ),
+                      );
+                    },
+                  ),
+                if (availableHosts.isNotEmpty)
+                  DropdownButtonFormField<String>(
+                    decoration: const InputDecoration(
+                      labelText: '添加跳板机',
+                      prefixIcon: Icon(Icons.add_road),
+                    ),
+                    items: [
+                      for (final value in availableHosts)
+                        DropdownMenuItem(
+                          value: value.id,
+                          child: Text(value.label),
+                        ),
+                    ],
+                    onChanged: (value) {
+                      if (value != null) setState(() => jumpHostIds.add(value));
+                    },
+                  ),
+                _section('代理'),
+                DropdownButtonFormField<String>(
+                  initialValue: proxyMode,
+                  decoration: const InputDecoration(labelText: '代理方式'),
+                  items: [
+                    const DropdownMenuItem(
+                      value: 'none',
+                      child: Text('不使用代理'),
+                    ),
+                    const DropdownMenuItem(
+                      value: 'custom',
+                      child: Text('自定义 HTTP / SOCKS5 代理'),
+                    ),
+                    for (final profile in profiles)
+                      DropdownMenuItem(
+                        value: 'profile:${profile.id}',
+                        child: Text('已保存 · ${profile.label}'),
+                      ),
+                  ],
+                  onChanged: (value) =>
+                      setState(() => proxyMode = value ?? 'none'),
+                ),
+                if (proxyMode == 'custom') ...[
+                  const SizedBox(height: 12),
+                  SegmentedButton<ProxyType>(
+                    segments: const [
+                      ButtonSegment(value: ProxyType.http, label: Text('HTTP')),
+                      ButtonSegment(
+                        value: ProxyType.socks5,
+                        label: Text('SOCKS5'),
+                      ),
+                    ],
+                    selected: {proxyType},
+                    onSelectionChanged: (value) =>
+                        setState(() => proxyType = value.first),
+                  ),
+                  const SizedBox(height: 12),
+                  Row(
+                    children: [
+                      Expanded(
+                        flex: 2,
+                        child: TextFormField(
+                          controller: proxyHost,
+                          decoration: const InputDecoration(labelText: '代理主机'),
+                          validator: proxyMode == 'custom' ? _required : null,
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: TextFormField(
+                          controller: proxyPort,
+                          decoration: const InputDecoration(labelText: '端口'),
+                          keyboardType: TextInputType.number,
+                          validator: proxyMode == 'custom' ? _validPort : null,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: proxyUsername,
+                    decoration: const InputDecoration(labelText: '代理用户名（可选）'),
+                  ),
+                  const SizedBox(height: 12),
+                  TextFormField(
+                    controller: proxyPassword,
+                    obscureText: obscureProxyPassword,
+                    decoration: InputDecoration(
+                      labelText: '代理密码（可选）',
+                      suffixIcon: IconButton(
+                        onPressed: () => setState(
+                          () => obscureProxyPassword = !obscureProxyPassword,
+                        ),
+                        icon: Icon(
+                          obscureProxyPassword
+                              ? Icons.visibility
+                              : Icons.visibility_off,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+                _section('高级选项'),
+                TextFormField(
+                  controller: startupCommand,
+                  minLines: 1,
+                  maxLines: 4,
+                  decoration: const InputDecoration(labelText: '连接后执行命令（可选）'),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: keepalive,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(
+                          labelText: 'Keepalive（秒）',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextFormField(
+                        controller: connectTimeout,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(
+                          labelText: '连接超时（秒）',
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: 8),
+                    Expanded(
+                      child: TextFormField(
+                        controller: authTimeout,
+                        keyboardType: TextInputType.number,
+                        decoration: const InputDecoration(
+                          labelText: '认证超时（秒）',
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _section(String title) => Padding(
+        padding: const EdgeInsets.fromLTRB(2, 22, 2, 10),
+        child: Text(
+          title,
+          style: const TextStyle(fontWeight: FontWeight.w700, fontSize: 15),
+        ),
+      );
+
+  String? _required(String? value) =>
+      value == null || value.trim().isEmpty ? '必填' : null;
+
+  String? _validPort(String? value) {
+    final parsed = int.tryParse(value ?? '');
+    return parsed == null || parsed < 1 || parsed > 65535 ? '端口无效' : null;
+  }
+
+  Future<void> _openKeychain() => showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        useSafeArea: true,
+        builder: (_) => const KeychainSheet(),
+      );
+
+  void _save() {
+    if (!(_form.currentState?.validate() ?? false)) return;
+    if (authMethod == HostAuthMethod.key && identityFileId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('请选择用于认证的 SSH 私钥')),
+      );
+      return;
+    }
+    final base = widget.host ??
+        HostProfile.create(
+          id: const Uuid().v4(),
+          label: label.text.trim(),
+          hostname: hostname.text.trim(),
+          username: username.text.trim(),
+        );
+    final data = Map<String, dynamic>.from(base.data)
+      ..['label'] = label.text.trim()
+      ..['hostname'] = hostname.text.trim()
+      ..['username'] = username.text.trim()
+      ..['port'] = int.parse(port.text)
+      ..['protocol'] = protocol.name
+      ..['authMethod'] = authMethod.name
+      ..['savePassword'] = true
+      ..['pinned'] = pinned
+      ..['tags'] = tags.text
+          .split(RegExp(r'[,，]'))
+          .map((value) => value.trim())
+          .where((value) => value.isNotEmpty)
+          .toList()
+      ..['keepaliveOverride'] = true
+      ..['keepaliveInterval'] = int.tryParse(keepalive.text) ?? 10
+      ..['sshTcpConnectTimeoutSeconds'] =
+          int.tryParse(connectTimeout.text) ?? 15
+      ..['sshAuthReadyTimeoutSeconds'] = int.tryParse(authTimeout.text) ?? 30;
+    _setOrRemove(data, 'password', password.text.trim());
+    _setOrRemove(data, 'group', group.text.trim());
+    _setOrRemove(data, 'identityFileId', identityFileId);
+    _setOrRemove(data, 'startupCommand', startupCommand.text.trim());
+    if (jumpHostIds.isEmpty) {
+      data.remove('hostChain');
+    } else {
+      data['hostChain'] = {
+        'hostIds': [...jumpHostIds]
+      };
+    }
+    if (proxyMode == 'none') {
+      data.remove('proxyProfileId');
+      data.remove('proxyConfig');
+    } else if (proxyMode.startsWith('profile:')) {
+      data['proxyProfileId'] = proxyMode.substring('profile:'.length);
+      data.remove('proxyConfig');
+    } else {
+      data.remove('proxyProfileId');
+      data['proxyConfig'] = ProxyConfig(
+        type: proxyType,
+        host: proxyHost.text.trim(),
+        port: int.parse(proxyPort.text),
+        username: proxyUsername.text.trim(),
+        password: proxyPassword.text,
+      ).toJson();
+    }
+    Navigator.pop(context, HostProfile(data));
+  }
+
+  void _setOrRemove(Map<String, dynamic> data, String key, String? value) {
+    if (value == null || value.isEmpty) {
+      data.remove(key);
+    } else {
+      data[key] = value;
+    }
+  }
+}

--- a/test/vault_model_test.dart
+++ b/test/vault_model_test.dart
@@ -38,4 +38,57 @@ void main() {
     expect(snapshot.containsKey('convergentSync'), isFalse);
     expect(snapshot['pluginSidecars'], {'kept': true});
   });
+
+  test('host connection routing fields round-trip with desktop names', () {
+    final host = HostProfile({
+      'id': 'target',
+      'label': 'Production',
+      'hostname': 'prod.example.com',
+      'username': 'root',
+      'authMethod': 'key',
+      'identityFileId': 'key-1',
+      'hostChain': {
+        'hostIds': ['jump-1', 'jump-2'],
+      },
+      'proxyConfig': {
+        'type': 'socks5',
+        'host': '127.0.0.1',
+        'port': 1080,
+        'username': 'proxy-user',
+      },
+    });
+
+    expect(host.authMethod, HostAuthMethod.key);
+    expect(host.identityFileId, 'key-1');
+    expect(host.hostChainIds, ['jump-1', 'jump-2']);
+    expect(host.proxyConfig?.type, ProxyType.socks5);
+    expect(host.proxyConfig?.port, 1080);
+    expect(host.toJson()['hostChain'], {
+      'hostIds': ['jump-1', 'jump-2'],
+    });
+  });
+
+  test('vault preserves reusable desktop proxy profiles', () {
+    final vault = VaultData.fromJson({
+      'hosts': [],
+      'keys': [],
+      'snippets': [],
+      'customGroups': [],
+      'proxyProfiles': [
+        {
+          'id': 'proxy-1',
+          'label': 'Office SOCKS',
+          'config': {'type': 'socks5', 'host': 'proxy.local', 'port': 1080},
+          'createdAt': 1,
+        },
+      ],
+    });
+
+    expect(vault.proxyProfiles.single.label, 'Office SOCKS');
+    expect(vault.proxyProfiles.single.config?.host, 'proxy.local');
+    expect(
+      (vault.toJson()['proxyProfiles'] as List).single['id'],
+      'proxy-1',
+    );
+  });
 }


### PR DESCRIPTION
## What changed

- adds complete mobile connection editing for passwords, SSH private keys, jump-host chains, HTTP/SOCKS5 proxies, timeouts, keepalive, and startup commands
- shows connection details before connecting and supports multiple tabs for repeated connections to the same host
- changes terminal quick keys to a configurable two-row layout and adds a hide-keyboard action
- adds GitHub Device Flow login and automatic encrypted Gist discovery/creation using the configured OAuth Client ID
- keeps active Android SSH sessions alive with a foreground service and reconnects interrupted sessions when the app resumes
- builds an unsigned, re-signable iOS IPA artifact and keeps automatic Android APK artifacts

## Why

The mobile client should be independently usable without relying on desktop-side connection editing or manually creating GitHub tokens. Mobile lifecycle behavior and package distribution also need platform-appropriate handling.

## Validation

- `dart analyze` — passed
- `flutter test --no-pub` — 6 tests passed
- `flutter build apk --release --no-pub --dart-define=GITHUB_OAUTH_CLIENT_ID=Ov23lidR2u8OIkHW19nk` — passed
- CI workflow YAML parse — passed
- local APK SHA-256: `0002CAC19ACCD5483173A31AB12B33B7323054E8875C3576F47FD5CFA856137B`

The iOS source and workflow cannot be compiled locally on Windows; GitHub Actions runs that build on macOS without code signing and packages the resulting app as a re-signable IPA.