### PR TITLE
Fix resilient GitHub device login

### DIFF
--- a/lib/infrastructure/sync/github_auth_service.dart
+++ b/lib/infrastructure/sync/github_auth_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:http/http.dart' as http;
 
@@ -19,8 +20,33 @@ class GitHubDeviceAuthorization {
   final Duration interval;
 }
 
+enum GitHubAuthPollState { waitingForAuthorization, retryingNetwork }
+
+class GitHubAuthCancelledException implements Exception {
+  const GitHubAuthCancelledException();
+
+  @override
+  String toString() => 'GitHub 登录已取消';
+}
+
+class GitHubAuthNetworkException implements Exception {
+  const GitHubAuthNetworkException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+typedef GitHubAuthDelay = Future<void> Function(Duration duration);
+
 class GitHubAuthService {
-  GitHubAuthService({http.Client? client}) : _client = client ?? http.Client();
+  GitHubAuthService({
+    http.Client? client,
+    GitHubAuthDelay? delay,
+    this.requestTimeout = const Duration(seconds: 20),
+  })  : _client = client ?? http.Client(),
+        _delay = delay ?? Future<void>.delayed;
 
   static const clientId = String.fromEnvironment(
     'GITHUB_OAUTH_CLIENT_ID',
@@ -28,17 +54,31 @@ class GitHubAuthService {
   );
 
   final http.Client _client;
+  final GitHubAuthDelay _delay;
+  final Duration requestTimeout;
 
   Future<GitHubDeviceAuthorization> start() async {
-    final response = await _client.post(
-      Uri.parse('https://github.com/login/device/code'),
-      headers: const {'accept': 'application/json'},
-      body: const {'client_id': clientId, 'scope': 'gist read:user'},
-    );
+    late final http.Response response;
+    try {
+      response = await _client.post(
+        Uri.parse('https://github.com/login/device/code'),
+        headers: const {'accept': 'application/json'},
+        body: const {'client_id': clientId, 'scope': 'gist read:user'},
+      ).timeout(requestTimeout);
+    } on Object catch (error) {
+      if (_isTransient(error)) {
+        throw const GitHubAuthNetworkException(
+          '无法连接 GitHub，请检查网络、VPN或代理后重试',
+        );
+      }
+      rethrow;
+    }
     final json = _json(response);
     if (response.statusCode < 200 || response.statusCode >= 300) {
       throw StateError(
-          json['error_description']?.toString() ?? 'GitHub 授权启动失败');
+        json['error_description']?.toString() ??
+            'GitHub 授权启动失败（HTTP ${response.statusCode}）',
+      );
     }
     return GitHubDeviceAuthorization(
       deviceCode: json['device_code'].toString(),
@@ -51,20 +91,50 @@ class GitHubAuthService {
     );
   }
 
-  Future<String> poll(GitHubDeviceAuthorization authorization) async {
+  Future<String> poll(
+    GitHubDeviceAuthorization authorization, {
+    bool Function()? isCancelled,
+    void Function(GitHubAuthPollState state)? onStateChanged,
+  }) async {
     var interval = authorization.interval;
+    onStateChanged?.call(GitHubAuthPollState.waitingForAuthorization);
     while (DateTime.now().isBefore(authorization.expiresAt)) {
-      await Future<void>.delayed(interval);
-      final response = await _client.post(
-        Uri.parse('https://github.com/login/oauth/access_token'),
-        headers: const {'accept': 'application/json'},
-        body: {
-          'client_id': clientId,
-          'device_code': authorization.deviceCode,
-          'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
-        },
-      );
+      _throwIfCancelled(isCancelled);
+      await _delay(interval);
+      _throwIfCancelled(isCancelled);
+
+      http.Response response;
+      try {
+        response = await _client.post(
+          Uri.parse('https://github.com/login/oauth/access_token'),
+          headers: const {'accept': 'application/json'},
+          body: {
+            'client_id': clientId,
+            'device_code': authorization.deviceCode,
+            'grant_type': 'urn:ietf:params:oauth:grant-type:device_code',
+          },
+        ).timeout(requestTimeout);
+      } on Object catch (error) {
+        if (_isTransient(error)) {
+          onStateChanged?.call(GitHubAuthPollState.retryingNetwork);
+          continue;
+        }
+        rethrow;
+      }
+
+      if (_isRetryableStatus(response.statusCode)) {
+        onStateChanged?.call(GitHubAuthPollState.retryingNetwork);
+        continue;
+      }
       final json = _json(response);
+      if (response.statusCode < 200 || response.statusCode >= 300) {
+        throw StateError(
+          json['error_description']?.toString() ??
+              'GitHub 授权请求失败（HTTP ${response.statusCode}）',
+        );
+      }
+
+      onStateChanged?.call(GitHubAuthPollState.waitingForAuthorization);
       final token = json['access_token']?.toString();
       if (token?.isNotEmpty == true) return token!;
       switch (json['error']?.toString()) {
@@ -81,31 +151,79 @@ class GitHubAuthService {
           throw StateError(
             json['error_description']?.toString() ?? 'GitHub 授权失败：$error',
           );
+        default:
+          throw StateError('GitHub 返回了无法识别的授权响应');
       }
     }
     throw StateError('GitHub 验证码已过期，请重新登录');
   }
 
   Future<Map<String, dynamic>> currentUser(String token) async {
-    final response = await _client.get(
-      Uri.parse('https://api.github.com/user'),
-      headers: {
-        'accept': 'application/vnd.github+json',
-        'authorization': 'Bearer $token',
-        'x-github-api-version': '2022-11-28',
-      },
-    );
-    final json = _json(response);
-    if (response.statusCode < 200 || response.statusCode >= 300) {
-      throw StateError('GitHub 登录状态无效 (${response.statusCode})');
+    for (var attempt = 0; attempt < 3; attempt++) {
+      if (attempt > 0) {
+        await _delay(Duration(seconds: attempt * 2));
+      }
+      try {
+        final response = await _client.get(
+          Uri.parse('https://api.github.com/user'),
+          headers: {
+            'accept': 'application/vnd.github+json',
+            'authorization': 'Bearer $token',
+            'x-github-api-version': '2022-11-28',
+          },
+        ).timeout(requestTimeout);
+        if (_isRetryableStatus(response.statusCode)) {
+          if (attempt < 2) continue;
+          throw GitHubAuthNetworkException(
+            '已取得 GitHub 授权，但暂时无法读取用户信息（HTTP ${response.statusCode}）',
+          );
+        }
+        final json = _json(response);
+        if (response.statusCode < 200 || response.statusCode >= 300) {
+          throw StateError('GitHub 登录状态无效（${response.statusCode}）');
+        }
+        return json;
+      } on Object catch (error) {
+        if (_isTransient(error)) {
+          if (attempt < 2) continue;
+          throw const GitHubAuthNetworkException(
+            '已取得 GitHub 授权，但网络仍不可用；Token 已安全保存，可稍后直接同步',
+          );
+        }
+        rethrow;
+      }
     }
-    return json;
+    throw const GitHubAuthNetworkException('暂时无法读取 GitHub 用户信息');
   }
 
+  void _throwIfCancelled(bool Function()? isCancelled) {
+    if (isCancelled?.call() == true) {
+      throw const GitHubAuthCancelledException();
+    }
+  }
+
+  bool _isTransient(Object error) =>
+      error is http.ClientException ||
+      error is SocketException ||
+      error is HandshakeException ||
+      error is TimeoutException;
+
+  bool _isRetryableStatus(int statusCode) =>
+      statusCode == 408 ||
+      statusCode == 429 ||
+      statusCode == 500 ||
+      statusCode == 502 ||
+      statusCode == 503 ||
+      statusCode == 504;
+
   Map<String, dynamic> _json(http.Response response) {
-    final value = jsonDecode(response.body);
-    return value is Map
-        ? Map<String, dynamic>.from(value)
-        : <String, dynamic>{};
+    try {
+      final value = jsonDecode(response.body);
+      return value is Map
+          ? Map<String, dynamic>.from(value)
+          : <String, dynamic>{};
+    } on FormatException {
+      return <String, dynamic>{};
+    }
   }
 }

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -412,14 +412,19 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
         barrierDismissible: false,
         builder: (_) => _GitHubDeviceFlowDialog(
           authorization: authorization,
-          tokenFuture: auth.poll(authorization),
+          auth: auth,
         ),
       );
       if (token == null || !mounted) return;
-      final user = await auth.currentUser(token);
       providerSecret.text = token;
       resourceId.clear();
-      _githubUser = user['login']?.toString();
+      await _saveSync();
+      try {
+        final user = await auth.currentUser(token);
+        _githubUser = user['login']?.toString();
+      } on GitHubAuthNetworkException {
+        _githubUser = null;
+      }
       await _saveSync();
       if (mounted) setState(() {});
       _message('GitHub 登录成功，将自动查找 Netcatty Gist');
@@ -532,11 +537,11 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
 class _GitHubDeviceFlowDialog extends StatefulWidget {
   const _GitHubDeviceFlowDialog({
     required this.authorization,
-    required this.tokenFuture,
+    required this.auth,
   });
 
   final GitHubDeviceAuthorization authorization;
-  final Future<String> tokenFuture;
+  final GitHubAuthService auth;
 
   @override
   State<_GitHubDeviceFlowDialog> createState() =>
@@ -545,6 +550,8 @@ class _GitHubDeviceFlowDialog extends StatefulWidget {
 
 class _GitHubDeviceFlowDialogState extends State<_GitHubDeviceFlowDialog> {
   Object? error;
+  GitHubAuthPollState state = GitHubAuthPollState.waitingForAuthorization;
+  bool cancelled = false;
 
   @override
   void initState() {
@@ -553,11 +560,30 @@ class _GitHubDeviceFlowDialogState extends State<_GitHubDeviceFlowDialog> {
       ClipboardData(text: widget.authorization.userCode),
     ));
     unawaited(_openGitHub());
-    widget.tokenFuture.then((token) {
+    unawaited(_poll());
+  }
+
+  @override
+  void dispose() {
+    cancelled = true;
+    super.dispose();
+  }
+
+  Future<void> _poll() async {
+    try {
+      final token = await widget.auth.poll(
+        widget.authorization,
+        isCancelled: () => cancelled,
+        onStateChanged: (value) {
+          if (mounted) setState(() => state = value);
+        },
+      );
       if (mounted) Navigator.pop(context, token);
-    }).catchError((Object value) {
+    } on GitHubAuthCancelledException {
+      // Closing the dialog intentionally stops the pending device flow.
+    } on Object catch (value) {
       if (mounted) setState(() => error = value);
-    });
+    }
   }
 
   Future<void> _openGitHub() => launchUrl(
@@ -592,7 +618,12 @@ class _GitHubDeviceFlowDialogState extends State<_GitHubDeviceFlowDialog> {
             if (error == null) ...[
               const LinearProgressIndicator(),
               const SizedBox(height: 8),
-              const Text('正在等待 GitHub 授权…'),
+              Text(
+                state == GitHubAuthPollState.retryingNetwork
+                    ? '网络连接发生变化，正在自动重试…'
+                    : '正在等待 GitHub 授权…',
+                textAlign: TextAlign.center,
+              ),
             ] else
               Text(
                 '$error',

--- a/test/github_auth_service_test.dart
+++ b/test/github_auth_service_test.dart
@@ -1,0 +1,84 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:netcatty_mobile/infrastructure/sync/github_auth_service.dart';
+
+void main() {
+  GitHubDeviceAuthorization authorization() => GitHubDeviceAuthorization(
+        deviceCode: 'device-code',
+        userCode: 'ABCD-1234',
+        verificationUri: Uri.parse('https://github.com/login/device'),
+        expiresAt: DateTime.now().add(const Duration(minutes: 1)),
+        interval: Duration.zero,
+      );
+
+  test('device polling recovers from an aborted mobile connection', () async {
+    var requests = 0;
+    final states = <GitHubAuthPollState>[];
+    final client = MockClient((request) async {
+      requests++;
+      if (requests == 1) {
+        throw http.ClientException('Software caused connection abort');
+      }
+      if (requests == 2) {
+        return http.Response(
+          jsonEncode({'error': 'authorization_pending'}),
+          200,
+        );
+      }
+      return http.Response(jsonEncode({'access_token': 'token-123'}), 200);
+    });
+    final service = GitHubAuthService(
+      client: client,
+      delay: (_) async {},
+    );
+
+    final token = await service.poll(
+      authorization(),
+      onStateChanged: states.add,
+    );
+
+    expect(token, 'token-123');
+    expect(requests, 3);
+    expect(states, contains(GitHubAuthPollState.retryingNetwork));
+    expect(states.last, GitHubAuthPollState.waitingForAuthorization);
+  });
+
+  test('closing the login dialog cancels polling before a request', () async {
+    var requests = 0;
+    final service = GitHubAuthService(
+      client: MockClient((request) async {
+        requests++;
+        return http.Response('{}', 200);
+      }),
+      delay: (_) async {},
+    );
+
+    await expectLater(
+      service.poll(authorization(), isCancelled: () => true),
+      throwsA(isA<GitHubAuthCancelledException>()),
+    );
+    expect(requests, 0);
+  });
+
+  test('user lookup retries a transient connection abort', () async {
+    var requests = 0;
+    final service = GitHubAuthService(
+      client: MockClient((request) async {
+        requests++;
+        if (requests == 1) {
+          throw http.ClientException('Software caused connection abort');
+        }
+        return http.Response(jsonEncode({'login': 'netcatty-user'}), 200);
+      }),
+      delay: (_) async {},
+    );
+
+    final user = await service.currentUser('token-123');
+
+    expect(user['login'], 'netcatty-user');
+    expect(requests, 2);
+  });
+}


### PR DESCRIPTION
## 问题原因

GitHub Device Flow 在应用切换到外部浏览器、VPN或移动网络发生变化时，轮询 Token 的 HTTP 连接可能被系统中止。原实现把单次 `ClientException` 当作永久失败，因此已经授权的登录也无法完成；取消弹窗后轮询 Future 也没有真正停止。

## 修复内容

- 对连接中止、超时、TLS握手异常及临时 HTTP 状态自动重试
- 继续遵守 GitHub Device Flow 的 `interval` 与 `slow_down` 规则
- 登录窗口关闭时取消轮询
- 获得 Token 后先安全保存，读取用户名临时失败不再丢失登录状态
- UI 将瞬时网络错误显示为自动重试状态
- 增加连接中止、取消轮询和用户信息重试测试

## 验证

- `dart analyze`：通过
- `flutter test --no-pub`：9 项测试通过
- Android Release APK 本地编译：通过
- APK SHA-256：`925E340F802BB3EDC47A78BD2FA6F260626FF3785240A61DBAEE92A80BC995C1`