### PR TITLE
feat: add terminal fullscreen and fix iOS storage

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
             android:name=".MainActivity"
             android:exported="true"
             android:launchMode="singleTask"
+            android:supportsPictureInPicture="true"
             android:taskAffinity=""
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"

--- a/android/app/src/main/kotlin/app/netcatty/mobile/MainActivity.kt
+++ b/android/app/src/main/kotlin/app/netcatty/mobile/MainActivity.kt
@@ -1,9 +1,12 @@
 package app.netcatty.mobile
 
 import android.Manifest
+import android.app.PictureInPictureParams
+import android.content.res.Configuration
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
+import android.util.Rational
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterActivity
@@ -12,6 +15,7 @@ import io.flutter.plugin.common.MethodChannel
 
 class MainActivity : FlutterActivity() {
     private var documentTreeChannel: DocumentTreeChannel? = null
+    private var pictureInPictureChannel: MethodChannel? = null
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -41,6 +45,45 @@ class MainActivity : FlutterActivity() {
                 else -> result.notImplemented()
             }
         }
+        pictureInPictureChannel = MethodChannel(
+            flutterEngine.dartExecutor.binaryMessenger,
+            "app.netcatty.mobile/picture_in_picture",
+        ).also { channel ->
+            channel.setMethodCallHandler { call, result ->
+                when (call.method) {
+                    "isSupported" -> result.success(isPictureInPictureSupported())
+                    "enter" -> {
+                        if (!isPictureInPictureSupported()) {
+                            result.success(false)
+                            return@setMethodCallHandler
+                        }
+                        val width = (call.argument<Number>("aspectWidth")?.toInt() ?: 16)
+                            .coerceAtLeast(1)
+                        val height = (call.argument<Number>("aspectHeight")?.toInt() ?: 9)
+                            .coerceAtLeast(1)
+                        val params = PictureInPictureParams.Builder()
+                            .setAspectRatio(Rational(width, height))
+                            .build()
+                        result.success(enterPictureInPictureMode(params))
+                    }
+                    // Android displays the live Flutter surface, so it doesn't need
+                    // the text frames used by iOS.
+                    "update", "stop" -> result.success(null)
+                    else -> result.notImplemented()
+                }
+            }
+        }
+    }
+
+    override fun onPictureInPictureModeChanged(
+        isInPictureInPictureMode: Boolean,
+        newConfig: Configuration,
+    ) {
+        super.onPictureInPictureModeChanged(isInPictureInPictureMode, newConfig)
+        pictureInPictureChannel?.invokeMethod(
+            "stateChanged",
+            mapOf("active" to isInPictureInPictureMode),
+        )
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
@@ -53,8 +96,14 @@ class MainActivity : FlutterActivity() {
     override fun onDestroy() {
         documentTreeChannel?.dispose()
         documentTreeChannel = null
+        pictureInPictureChannel?.setMethodCallHandler(null)
+        pictureInPictureChannel = null
         super.onDestroy()
     }
+
+    private fun isPictureInPictureSupported(): Boolean =
+        Build.VERSION.SDK_INT >= Build.VERSION_CODES.O &&
+            packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
 
     private fun requestNotificationPermission() {
         if (

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,9 +1,14 @@
 import Flutter
 import UIKit
+import UniformTypeIdentifiers
 
 @main
-@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate, UIDocumentPickerDelegate {
   private var sshBackgroundTask: UIBackgroundTaskIdentifier = .invalid
+  private var directoryPickerResult: FlutterResult?
+  private var mountedDirectoryURL: URL?
+  private var mountedDirectoryHasSecurityAccess = false
+  private let directoryBookmarkKey = "netcatty.ios.mountedDirectoryBookmark"
 
   override func application(
     _ application: UIApplication,
@@ -32,6 +37,148 @@ import UIKit
         result(FlutterMethodNotImplemented)
       }
     }
+    let storageChannel = FlutterMethodChannel(
+      name: "app.netcatty.mobile/storage",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+    storageChannel.setMethodCallHandler { [weak self] call, result in
+      guard let self else {
+        result(FlutterError(code: "unavailable", message: "Storage service is unavailable", details: nil))
+        return
+      }
+      switch call.method {
+      case "getMount":
+        result(self.restoreDirectoryMount())
+      case "mount":
+        self.presentDirectoryPicker(result: result)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  private func presentDirectoryPicker(result: @escaping FlutterResult) {
+    guard directoryPickerResult == nil else {
+      result(FlutterError(code: "already_active", message: "A directory picker is already open", details: nil))
+      return
+    }
+    guard let presenter = activeViewController() else {
+      result(FlutterError(code: "unavailable", message: "Unable to present the directory picker", details: nil))
+      return
+    }
+    let picker: UIDocumentPickerViewController
+    if #available(iOS 14.0, *) {
+      picker = UIDocumentPickerViewController(forOpeningContentTypes: [.folder], asCopy: false)
+    } else {
+      picker = UIDocumentPickerViewController(documentTypes: ["public.folder"], in: .open)
+    }
+    picker.delegate = self
+    picker.allowsMultipleSelection = false
+    directoryPickerResult = result
+    presenter.present(picker, animated: true)
+  }
+
+  func documentPicker(
+    _ controller: UIDocumentPickerViewController,
+    didPickDocumentsAt urls: [URL]
+  ) {
+    guard let result = directoryPickerResult else { return }
+    directoryPickerResult = nil
+    guard let url = urls.first else {
+      result(nil)
+      return
+    }
+    do {
+      result(try activateDirectoryMount(url, persist: true))
+    } catch {
+      result(FlutterError(code: "directory_access_failed", message: error.localizedDescription, details: nil))
+    }
+  }
+
+  func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+    let result = directoryPickerResult
+    directoryPickerResult = nil
+    result?(nil)
+  }
+
+  private func restoreDirectoryMount() -> [String: Any] {
+    if let url = mountedDirectoryURL {
+      return directoryMountPayload(url)
+    }
+    guard let bookmark = UserDefaults.standard.data(forKey: directoryBookmarkKey) else {
+      return ["mounted": false]
+    }
+    do {
+      var stale = false
+      let url = try URL(
+        resolvingBookmarkData: bookmark,
+        options: [],
+        relativeTo: nil,
+        bookmarkDataIsStale: &stale
+      )
+      let payload = try activateDirectoryMount(url, persist: stale)
+      return payload
+    } catch {
+      UserDefaults.standard.removeObject(forKey: directoryBookmarkKey)
+      return ["mounted": false]
+    }
+  }
+
+  private func activateDirectoryMount(_ url: URL, persist: Bool) throws -> [String: Any] {
+    releaseDirectoryMount()
+    let granted = url.startAccessingSecurityScopedResource()
+    guard granted || FileManager.default.fileExists(atPath: url.path) else {
+      throw NSError(
+        domain: "app.netcatty.mobile.storage",
+        code: 1,
+        userInfo: [NSLocalizedDescriptionKey: "无法访问所选目录，请在系统文件选择器中重新授权。"]
+      )
+    }
+    mountedDirectoryURL = url
+    mountedDirectoryHasSecurityAccess = granted
+    if persist {
+      do {
+        let bookmark = try url.bookmarkData(
+          options: .minimalBookmark,
+          includingResourceValuesForKeys: nil,
+          relativeTo: nil
+        )
+        UserDefaults.standard.set(bookmark, forKey: directoryBookmarkKey)
+      } catch {
+        releaseDirectoryMount()
+        throw error
+      }
+    }
+    return directoryMountPayload(url)
+  }
+
+  private func directoryMountPayload(_ url: URL) -> [String: Any] {
+    return [
+      "mounted": true,
+      "path": url.path,
+      "name": url.lastPathComponent,
+    ]
+  }
+
+  private func releaseDirectoryMount() {
+    if mountedDirectoryHasSecurityAccess {
+      mountedDirectoryURL?.stopAccessingSecurityScopedResource()
+    }
+    mountedDirectoryURL = nil
+    mountedDirectoryHasSecurityAccess = false
+  }
+
+  private func activeViewController() -> UIViewController? {
+    let sceneController = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .flatMap { $0.windows }
+      .first { $0.isKeyWindow }?
+      .rootViewController
+    var controller = sceneController ?? window?.rootViewController
+    while let presented = controller?.presentedViewController {
+      controller = presented
+    }
+    return controller
   }
 
   private func beginSshBackgroundGrace() {
@@ -47,5 +194,11 @@ import UIKit
     guard sshBackgroundTask != .invalid else { return }
     UIApplication.shared.endBackgroundTask(sshBackgroundTask)
     sshBackgroundTask = .invalid
+  }
+
+  override func applicationWillTerminate(_ application: UIApplication) {
+    releaseDirectoryMount()
+    endSshBackgroundGrace()
+    super.applicationWillTerminate(application)
   }
 }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -4,15 +4,10 @@ import CoreMedia
 import CoreVideo
 import Flutter
 import UIKit
-import UniformTypeIdentifiers
 
 @main
-@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate, UIDocumentPickerDelegate {
+@objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   private var sshBackgroundTask: UIBackgroundTaskIdentifier = .invalid
-  private var directoryPickerResult: FlutterResult?
-  private var mountedDirectoryURL: URL?
-  private var mountedDirectoryHasSecurityAccess = false
-  private let directoryBookmarkKey = "netcatty.ios.mountedDirectoryBookmark"
   private var pictureInPictureChannel: FlutterMethodChannel?
   private var terminalPictureInPictureStorage: AnyObject?
 
@@ -39,24 +34,6 @@ import UniformTypeIdentifiers
         result(nil)
       case "setActive":
         result(nil)
-      default:
-        result(FlutterMethodNotImplemented)
-      }
-    }
-    let storageChannel = FlutterMethodChannel(
-      name: "app.netcatty.mobile/storage",
-      binaryMessenger: engineBridge.applicationRegistrar.messenger()
-    )
-    storageChannel.setMethodCallHandler { [weak self] call, result in
-      guard let self else {
-        result(FlutterError(code: "unavailable", message: "Storage service is unavailable", details: nil))
-        return
-      }
-      switch call.method {
-      case "getMount":
-        result(self.restoreDirectoryMount())
-      case "mount":
-        self.presentDirectoryPicker(result: result)
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -137,117 +114,6 @@ import UniformTypeIdentifiers
     return false
   }
 
-  private func presentDirectoryPicker(result: @escaping FlutterResult) {
-    guard directoryPickerResult == nil else {
-      result(FlutterError(code: "already_active", message: "A directory picker is already open", details: nil))
-      return
-    }
-    guard let presenter = activeViewController() else {
-      result(FlutterError(code: "unavailable", message: "Unable to present the directory picker", details: nil))
-      return
-    }
-    let picker: UIDocumentPickerViewController
-    if #available(iOS 14.0, *) {
-      picker = UIDocumentPickerViewController(forOpeningContentTypes: [.folder], asCopy: false)
-    } else {
-      picker = UIDocumentPickerViewController(documentTypes: ["public.folder"], in: .open)
-    }
-    picker.delegate = self
-    picker.allowsMultipleSelection = false
-    directoryPickerResult = result
-    presenter.present(picker, animated: true)
-  }
-
-  func documentPicker(
-    _ controller: UIDocumentPickerViewController,
-    didPickDocumentsAt urls: [URL]
-  ) {
-    guard let result = directoryPickerResult else { return }
-    directoryPickerResult = nil
-    guard let url = urls.first else {
-      result(nil)
-      return
-    }
-    do {
-      result(try activateDirectoryMount(url, persist: true))
-    } catch {
-      result(FlutterError(code: "directory_access_failed", message: error.localizedDescription, details: nil))
-    }
-  }
-
-  func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
-    let result = directoryPickerResult
-    directoryPickerResult = nil
-    result?(nil)
-  }
-
-  private func restoreDirectoryMount() -> [String: Any] {
-    if let url = mountedDirectoryURL {
-      return directoryMountPayload(url)
-    }
-    guard let bookmark = UserDefaults.standard.data(forKey: directoryBookmarkKey) else {
-      return ["mounted": false]
-    }
-    do {
-      var stale = false
-      let url = try URL(
-        resolvingBookmarkData: bookmark,
-        options: [],
-        relativeTo: nil,
-        bookmarkDataIsStale: &stale
-      )
-      let payload = try activateDirectoryMount(url, persist: stale)
-      return payload
-    } catch {
-      UserDefaults.standard.removeObject(forKey: directoryBookmarkKey)
-      return ["mounted": false]
-    }
-  }
-
-  private func activateDirectoryMount(_ url: URL, persist: Bool) throws -> [String: Any] {
-    releaseDirectoryMount()
-    let granted = url.startAccessingSecurityScopedResource()
-    guard granted || FileManager.default.fileExists(atPath: url.path) else {
-      throw NSError(
-        domain: "app.netcatty.mobile.storage",
-        code: 1,
-        userInfo: [NSLocalizedDescriptionKey: "无法访问所选目录，请在系统文件选择器中重新授权。"]
-      )
-    }
-    mountedDirectoryURL = url
-    mountedDirectoryHasSecurityAccess = granted
-    if persist {
-      do {
-        let bookmark = try url.bookmarkData(
-          options: .minimalBookmark,
-          includingResourceValuesForKeys: nil,
-          relativeTo: nil
-        )
-        UserDefaults.standard.set(bookmark, forKey: directoryBookmarkKey)
-      } catch {
-        releaseDirectoryMount()
-        throw error
-      }
-    }
-    return directoryMountPayload(url)
-  }
-
-  private func directoryMountPayload(_ url: URL) -> [String: Any] {
-    return [
-      "mounted": true,
-      "path": url.path,
-      "name": url.lastPathComponent,
-    ]
-  }
-
-  private func releaseDirectoryMount() {
-    if mountedDirectoryHasSecurityAccess {
-      mountedDirectoryURL?.stopAccessingSecurityScopedResource()
-    }
-    mountedDirectoryURL = nil
-    mountedDirectoryHasSecurityAccess = false
-  }
-
   private func activeViewController() -> UIViewController? {
     let sceneController = UIApplication.shared.connectedScenes
       .compactMap { $0 as? UIWindowScene }
@@ -282,7 +148,6 @@ import UniformTypeIdentifiers
        let controller = terminalPictureInPictureStorage as? TerminalPictureInPictureController {
       controller.stop()
     }
-    releaseDirectoryMount()
     endSshBackgroundGrace()
     super.applicationWillTerminate(application)
   }
@@ -525,8 +390,6 @@ private final class TerminalPictureInPictureController: NSObject {
             bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue |
               CGBitmapInfo.byteOrder32Little.rawValue
           ) else { return nil }
-    context.translateBy(x: 0, y: CGFloat(height))
-    context.scaleBy(x: 1, y: -1)
     context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
     return pixelBuffer
   }

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,3 +1,7 @@
+import AVFoundation
+import AVKit
+import CoreMedia
+import CoreVideo
 import Flutter
 import UIKit
 import UniformTypeIdentifiers
@@ -9,6 +13,8 @@ import UniformTypeIdentifiers
   private var mountedDirectoryURL: URL?
   private var mountedDirectoryHasSecurityAccess = false
   private let directoryBookmarkKey = "netcatty.ios.mountedDirectoryBookmark"
+  private var pictureInPictureChannel: FlutterMethodChannel?
+  private var terminalPictureInPictureStorage: AnyObject?
 
   override func application(
     _ application: UIApplication,
@@ -55,6 +61,80 @@ import UniformTypeIdentifiers
         result(FlutterMethodNotImplemented)
       }
     }
+    let pictureInPictureChannel = FlutterMethodChannel(
+      name: "app.netcatty.mobile/picture_in_picture",
+      binaryMessenger: engineBridge.applicationRegistrar.messenger()
+    )
+    self.pictureInPictureChannel = pictureInPictureChannel
+    pictureInPictureChannel.setMethodCallHandler { [weak self] call, result in
+      guard let self else {
+        result(false)
+        return
+      }
+      guard #available(iOS 15.0, *) else {
+        if call.method == "isSupported" || call.method == "enter" {
+          result(false)
+        } else {
+          result(nil)
+        }
+        return
+      }
+      let controller = self.terminalPictureInPictureController()
+      switch call.method {
+      case "isSupported":
+        result(controller.isSupported)
+      case "enter":
+        guard let arguments = call.arguments as? [String: Any] else {
+          result(false)
+          return
+        }
+        controller.start(
+          arguments: arguments,
+          sourceView: self.activeViewController()?.view
+        ) { entered in
+          result(entered)
+        }
+      case "update":
+        if let arguments = call.arguments as? [String: Any] {
+          controller.update(arguments: arguments)
+        }
+        result(nil)
+      case "stop":
+        controller.stop()
+        result(nil)
+      default:
+        result(FlutterMethodNotImplemented)
+      }
+    }
+  }
+
+  @available(iOS 15.0, *)
+  private func terminalPictureInPictureController() -> TerminalPictureInPictureController {
+    if let existing = terminalPictureInPictureStorage as? TerminalPictureInPictureController {
+      return existing
+    }
+    let controller = TerminalPictureInPictureController { [weak self] active in
+      guard let self else { return }
+      self.pictureInPictureChannel?.invokeMethod(
+        "stateChanged",
+        arguments: ["active": active]
+      )
+      if active {
+        self.endSshBackgroundGrace()
+      } else if UIApplication.shared.applicationState != .active {
+        self.beginSshBackgroundGrace()
+      }
+    }
+    terminalPictureInPictureStorage = controller
+    return controller
+  }
+
+  private var isTerminalPictureInPictureActive: Bool {
+    if #available(iOS 15.0, *),
+       let controller = terminalPictureInPictureStorage as? TerminalPictureInPictureController {
+      return controller.isActiveOrStarting
+    }
+    return false
   }
 
   private func presentDirectoryPicker(result: @escaping FlutterResult) {
@@ -182,6 +262,7 @@ import UniformTypeIdentifiers
   }
 
   private func beginSshBackgroundGrace() {
+    guard !isTerminalPictureInPictureActive else { return }
     guard sshBackgroundTask == .invalid else { return }
     sshBackgroundTask = UIApplication.shared.beginBackgroundTask(
       withName: "Finish active SSH network work"
@@ -197,8 +278,413 @@ import UniformTypeIdentifiers
   }
 
   override func applicationWillTerminate(_ application: UIApplication) {
+    if #available(iOS 15.0, *),
+       let controller = terminalPictureInPictureStorage as? TerminalPictureInPictureController {
+      controller.stop()
+    }
     releaseDirectoryMount()
     endSshBackgroundGrace()
     super.applicationWillTerminate(application)
+  }
+}
+
+@available(iOS 15.0, *)
+private final class TerminalPictureInPictureController: NSObject {
+  private let displayLayer = AVSampleBufferDisplayLayer()
+  private let sourceContainer = UIView(frame: CGRect(x: 0, y: 0, width: 2, height: 2))
+  private let onStateChanged: (Bool) -> Void
+  private var pictureInPictureController: AVPictureInPictureController?
+  private var startCompletion: ((Bool) -> Void)?
+  private var starting = false
+
+  init(onStateChanged: @escaping (Bool) -> Void) {
+    self.onStateChanged = onStateChanged
+    super.init()
+    displayLayer.videoGravity = .resizeAspect
+    displayLayer.frame = sourceContainer.bounds
+    sourceContainer.isUserInteractionEnabled = false
+    sourceContainer.alpha = 0.01
+    sourceContainer.layer.addSublayer(displayLayer)
+  }
+
+  var isSupported: Bool {
+    AVPictureInPictureController.isPictureInPictureSupported()
+  }
+
+  var isActiveOrStarting: Bool {
+    starting || pictureInPictureController?.isPictureInPictureActive == true
+  }
+
+  func start(
+    arguments: [String: Any],
+    sourceView: UIView?,
+    completion: @escaping (Bool) -> Void
+  ) {
+    guard isSupported else {
+      completion(false)
+      return
+    }
+    if pictureInPictureController?.isPictureInPictureActive == true || starting {
+      completion(true)
+      return
+    }
+    attachSource(to: sourceView)
+    update(arguments: arguments)
+    configurePlaybackSession()
+    if pictureInPictureController == nil {
+      let source = AVPictureInPictureController.ContentSource(
+        sampleBufferDisplayLayer: displayLayer,
+        playbackDelegate: self
+      )
+      let controller = AVPictureInPictureController(contentSource: source)
+      controller.delegate = self
+      controller.requiresLinearPlayback = true
+      controller.canStartPictureInPictureAutomaticallyFromInline = false
+      pictureInPictureController = controller
+    }
+    starting = true
+    startCompletion = completion
+    attemptStart(remainingAttempts: 20)
+  }
+
+  func update(arguments: [String: Any]) {
+    let title = (arguments["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let text = arguments["text"] as? String ?? ""
+    let connected = arguments["connected"] as? Bool ?? false
+    let background = uiColor(
+      arguments["backgroundColor"],
+      fallback: 0xff111318
+    )
+    let foreground = uiColor(
+      arguments["foregroundColor"],
+      fallback: 0xffe4e2e8
+    )
+    let accent = uiColor(
+      arguments["accentColor"],
+      fallback: 0xffff8a3d
+    )
+    guard let pixelBuffer = renderFrame(
+      title: title?.isEmpty == false ? title! : "SSH Terminal",
+      text: text.isEmpty ? "等待终端输出…" : text,
+      connected: connected,
+      background: background,
+      foreground: foreground,
+      accent: accent
+    ) else { return }
+    enqueue(pixelBuffer)
+  }
+
+  func stop() {
+    starting = false
+    finishStart(false)
+    if pictureInPictureController?.isPictureInPictureActive == true {
+      pictureInPictureController?.stopPictureInPicture()
+    } else {
+      detachSource()
+      deactivatePlaybackSession()
+      onStateChanged(false)
+    }
+  }
+
+  private func attachSource(to view: UIView?) {
+    guard sourceContainer.superview == nil, let view else { return }
+    view.insertSubview(sourceContainer, at: 0)
+  }
+
+  private func detachSource() {
+    sourceContainer.removeFromSuperview()
+    displayLayer.flushAndRemoveImage()
+  }
+
+  private func configurePlaybackSession() {
+    let session = AVAudioSession.sharedInstance()
+    try? session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+    try? session.setActive(true)
+  }
+
+  private func deactivatePlaybackSession() {
+    try? AVAudioSession.sharedInstance().setActive(
+      false,
+      options: [.notifyOthersOnDeactivation]
+    )
+  }
+
+  private func attemptStart(remainingAttempts: Int) {
+    guard starting, let controller = pictureInPictureController else { return }
+    if controller.isPictureInPicturePossible {
+      controller.startPictureInPicture()
+      DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+        guard let self, self.starting else { return }
+        self.starting = false
+        self.finishStart(false)
+        self.onStateChanged(false)
+      }
+      return
+    }
+    guard remainingAttempts > 0 else {
+      starting = false
+      finishStart(false)
+      detachSource()
+      deactivatePlaybackSession()
+      onStateChanged(false)
+      return
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+      self?.attemptStart(remainingAttempts: remainingAttempts - 1)
+    }
+  }
+
+  private func finishStart(_ entered: Bool) {
+    let completion = startCompletion
+    startCompletion = nil
+    completion?(entered)
+  }
+
+  private func renderFrame(
+    title: String,
+    text: String,
+    connected: Bool,
+    background: UIColor,
+    foreground: UIColor,
+    accent: UIColor
+  ) -> CVPixelBuffer? {
+    let width = 960
+    let height = 540
+    let size = CGSize(width: width, height: height)
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    format.opaque = true
+    let image = UIGraphicsImageRenderer(size: size, format: format).image { renderer in
+      let context = renderer.cgContext
+      context.setFillColor(background.cgColor)
+      context.fill(CGRect(origin: .zero, size: size))
+
+      context.setFillColor(background.blended(with: foreground, amount: 0.08).cgColor)
+      context.fill(CGRect(x: 0, y: 0, width: width, height: 66))
+      context.setFillColor((connected ? UIColor.systemGreen : UIColor.systemOrange).cgColor)
+      context.fillEllipse(in: CGRect(x: 24, y: 25, width: 16, height: 16))
+
+      let titleAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 25, weight: .semibold),
+        .foregroundColor: foreground,
+      ]
+      (title as NSString).draw(
+        in: CGRect(x: 54, y: 17, width: width - 130, height: 36),
+        withAttributes: titleAttributes
+      )
+      let badgeAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.systemFont(ofSize: 19, weight: .medium),
+        .foregroundColor: accent,
+      ]
+      ("PiP" as NSString).draw(
+        in: CGRect(x: width - 72, y: 20, width: 52, height: 30),
+        withAttributes: badgeAttributes
+      )
+
+      let paragraph = NSMutableParagraphStyle()
+      paragraph.lineBreakMode = .byClipping
+      paragraph.minimumLineHeight = 25
+      paragraph.maximumLineHeight = 25
+      let terminalAttributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.monospacedSystemFont(ofSize: 20, weight: .regular),
+        .foregroundColor: foreground,
+        .paragraphStyle: paragraph,
+      ]
+      (text as NSString).draw(
+        in: CGRect(x: 22, y: 79, width: width - 44, height: height - 94),
+        withAttributes: terminalAttributes
+      )
+    }
+    guard let cgImage = image.cgImage else { return nil }
+
+    let attributes: [CFString: Any] = [
+      kCVPixelBufferCGImageCompatibilityKey: true,
+      kCVPixelBufferCGBitmapContextCompatibilityKey: true,
+      kCVPixelBufferIOSurfacePropertiesKey: [:] as CFDictionary,
+    ]
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferCreate(
+      kCFAllocatorDefault,
+      width,
+      height,
+      kCVPixelFormatType_32BGRA,
+      attributes as CFDictionary,
+      &pixelBuffer
+    )
+    guard status == kCVReturnSuccess, let pixelBuffer else { return nil }
+    CVPixelBufferLockBaseAddress(pixelBuffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
+    guard let baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer),
+          let context = CGContext(
+            data: baseAddress,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedFirst.rawValue |
+              CGBitmapInfo.byteOrder32Little.rawValue
+          ) else { return nil }
+    context.translateBy(x: 0, y: CGFloat(height))
+    context.scaleBy(x: 1, y: -1)
+    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+    return pixelBuffer
+  }
+
+  private func enqueue(_ pixelBuffer: CVPixelBuffer) {
+    if displayLayer.status == .failed {
+      displayLayer.flush()
+    }
+    guard displayLayer.isReadyForMoreMediaData else { return }
+    var formatDescription: CMVideoFormatDescription?
+    guard CMVideoFormatDescriptionCreateForImageBuffer(
+      allocator: kCFAllocatorDefault,
+      imageBuffer: pixelBuffer,
+      formatDescriptionOut: &formatDescription
+    ) == noErr, let formatDescription else { return }
+    var timing = CMSampleTimingInfo(
+      duration: CMTime(value: 1, timescale: 2),
+      presentationTimeStamp: CMClockGetTime(CMClockGetHostTimeClock()),
+      decodeTimeStamp: .invalid
+    )
+    var sampleBuffer: CMSampleBuffer?
+    guard CMSampleBufferCreateReadyWithImageBuffer(
+      allocator: kCFAllocatorDefault,
+      imageBuffer: pixelBuffer,
+      formatDescription: formatDescription,
+      sampleTiming: &timing,
+      sampleBufferOut: &sampleBuffer
+    ) == noErr, let sampleBuffer else { return }
+    if let attachments = CMSampleBufferGetSampleAttachmentsArray(
+      sampleBuffer,
+      createIfNecessary: true
+    ) {
+      let dictionary = unsafeBitCast(
+        CFArrayGetValueAtIndex(attachments, 0),
+        to: CFMutableDictionary.self
+      )
+      CFDictionarySetValue(
+        dictionary,
+        Unmanaged.passUnretained(kCMSampleAttachmentKey_DisplayImmediately).toOpaque(),
+        Unmanaged.passUnretained(kCFBooleanTrue).toOpaque()
+      )
+    }
+    displayLayer.enqueue(sampleBuffer)
+  }
+
+  private func uiColor(_ value: Any?, fallback: UInt32) -> UIColor {
+    let raw = UInt32(truncating: value as? NSNumber ?? NSNumber(value: fallback))
+    return UIColor(
+      red: CGFloat((raw >> 16) & 0xff) / 255,
+      green: CGFloat((raw >> 8) & 0xff) / 255,
+      blue: CGFloat(raw & 0xff) / 255,
+      alpha: CGFloat((raw >> 24) & 0xff) / 255
+    )
+  }
+}
+
+@available(iOS 15.0, *)
+extension TerminalPictureInPictureController: AVPictureInPictureSampleBufferPlaybackDelegate {
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    setPlaying playing: Bool
+  ) {}
+
+  func pictureInPictureControllerTimeRangeForPlayback(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) -> CMTimeRange {
+    CMTimeRange(start: .zero, duration: .positiveInfinity)
+  }
+
+  func pictureInPictureControllerIsPlaybackPaused(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) -> Bool {
+    false
+  }
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    didTransitionToRenderSize newRenderSize: CMVideoDimensions
+  ) {}
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    skipByInterval skipInterval: CMTime,
+    completion completionHandler: @escaping () -> Void
+  ) {
+    completionHandler()
+  }
+
+  func pictureInPictureControllerShouldProhibitBackgroundAudioPlayback(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) -> Bool {
+    true
+  }
+}
+
+@available(iOS 15.0, *)
+extension TerminalPictureInPictureController: AVPictureInPictureControllerDelegate {
+  func pictureInPictureControllerDidStartPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    starting = false
+    finishStart(true)
+    onStateChanged(true)
+  }
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    failedToStartPictureInPictureWithError error: Error
+  ) {
+    starting = false
+    finishStart(false)
+    detachSource()
+    deactivatePlaybackSession()
+    onStateChanged(false)
+  }
+
+  func pictureInPictureControllerDidStopPictureInPicture(
+    _ pictureInPictureController: AVPictureInPictureController
+  ) {
+    starting = false
+    finishStart(false)
+    detachSource()
+    deactivatePlaybackSession()
+    onStateChanged(false)
+  }
+
+  func pictureInPictureController(
+    _ pictureInPictureController: AVPictureInPictureController,
+    restoreUserInterfaceForPictureInPictureStopWithCompletionHandler completionHandler: @escaping (Bool) -> Void
+  ) {
+    let scene = UIApplication.shared.connectedScenes
+      .compactMap { $0 as? UIWindowScene }
+      .first
+    scene?.windows.first?.makeKeyAndVisible()
+    completionHandler(true)
+  }
+}
+
+private extension UIColor {
+  func blended(with color: UIColor, amount: CGFloat) -> UIColor {
+    var red1: CGFloat = 0
+    var green1: CGFloat = 0
+    var blue1: CGFloat = 0
+    var alpha1: CGFloat = 0
+    var red2: CGFloat = 0
+    var green2: CGFloat = 0
+    var blue2: CGFloat = 0
+    var alpha2: CGFloat = 0
+    guard getRed(&red1, green: &green1, blue: &blue1, alpha: &alpha1),
+          color.getRed(&red2, green: &green2, blue: &blue2, alpha: &alpha2) else {
+      return self
+    }
+    let fraction = min(max(amount, 0), 1)
+    return UIColor(
+      red: red1 + (red2 - red1) * fraction,
+      green: green1 + (green2 - green1) * fraction,
+      blue: blue1 + (blue2 - blue1) * fraction,
+      alpha: alpha1 + (alpha2 - alpha1) * fraction
+    )
   }
 }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -63,6 +63,10 @@
 	</dict>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -38,6 +38,8 @@
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>LSSupportsOpeningDocumentsInPlace</key>
+	<true/>
 	<key>NSFaceIDUsageDescription</key>
 	<string>Use Face ID to unlock saved Netcatty credentials.</string>
 	<key>UIApplicationSceneManifest</key>
@@ -67,6 +69,8 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>UIFileSharingEnabled</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -34,7 +34,8 @@ class _NetcattyAppState extends ConsumerState<NetcattyApp>
     if (state == AppLifecycleState.resumed) {
       ConnectionPlatformService.endBackgroundGrace();
       ref.read(sessionControllerProvider.notifier).reconnectDisconnected();
-    } else if (state == AppLifecycleState.paused ||
+    } else if (state == AppLifecycleState.inactive ||
+        state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden) {
       ConnectionPlatformService.beginBackgroundGrace();
     }

--- a/lib/infrastructure/ssh/sftp_service.dart
+++ b/lib/infrastructure/ssh/sftp_service.dart
@@ -4,7 +4,6 @@ import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'ssh_service.dart';
@@ -63,6 +62,7 @@ abstract class FileTransferService {
 abstract class MountableFileTransferService extends FileTransferService {
   bool get isMounted;
   String? get mountedDirectoryName;
+  bool get usesAppDocuments => false;
   Future<bool> mount();
 }
 
@@ -181,23 +181,22 @@ class SftpService extends FileTransferService {
 }
 
 class LocalFileTransferService extends MountableFileTransferService {
-  LocalFileTransferService._(this.rootPath, {this.isMounted = false});
-
-  static const _iosStorageChannel = MethodChannel(
-    'app.netcatty.mobile/storage',
-  );
+  LocalFileTransferService._(
+    this.rootPath, {
+    this.isMounted = false,
+    this.usesAppDocuments = false,
+  });
 
   static Future<LocalFileTransferService> create() async {
-    if (Platform.isIOS) {
-      final mount = await _iosStorageChannel.invokeMapMethod<String, dynamic>(
-        'getMount',
-      );
-      final path = mount?['path']?.toString();
-      if (mount?['mounted'] == true && path?.isNotEmpty == true) {
-        return LocalFileTransferService._(path!, isMounted: true);
-      }
-    }
     final documents = await getApplicationDocumentsDirectory();
+    if (Platform.isIOS) {
+      await documents.create(recursive: true);
+      return LocalFileTransferService._(
+        documents.path,
+        isMounted: true,
+        usesAppDocuments: true,
+      );
+    }
     final root = Directory(
       '${documents.path}${Platform.pathSeparator}Netcatty',
     );
@@ -210,30 +209,38 @@ class LocalFileTransferService extends MountableFileTransferService {
   @override
   bool isMounted;
   @override
-  String? get mountedDirectoryName => isMounted
-      ? Uri.file(rootPath).pathSegments.where((value) => value.isNotEmpty).last
-      : null;
+  final bool usesAppDocuments;
+  @override
+  String? get mountedDirectoryName {
+    if (!isMounted) return null;
+    if (usesAppDocuments) return 'Netcatty';
+    return Uri.file(rootPath)
+        .pathSegments
+        .where((value) => value.isNotEmpty)
+        .last;
+  }
+
   @override
   String get id => 'local';
   @override
-  String get displayName =>
-      isMounted ? '手机：${mountedDirectoryName ?? '已选目录'}' : '手机目录（未挂载）';
+  String get displayName => usesAppDocuments
+      ? '文件：Netcatty'
+      : isMounted
+          ? '手机：${mountedDirectoryName ?? '已选目录'}'
+          : '手机目录（未挂载）';
   @override
   bool get isLocal => true;
 
   @override
   Future<bool> mount() async {
-    final String? selected;
-    if (Platform.isIOS) {
-      final mount = await _iosStorageChannel.invokeMapMethod<String, dynamic>(
-        'mount',
-      );
-      selected = mount?['path']?.toString();
-    } else {
-      selected = await FilePicker.platform.getDirectoryPath(
-        dialogTitle: '选择要挂载到 SFTP 的手机目录',
-      );
+    if (usesAppDocuments) {
+      await Directory(rootPath).create(recursive: true);
+      isMounted = true;
+      return true;
     }
+    final selected = await FilePicker.platform.getDirectoryPath(
+      dialogTitle: '选择要挂载到 SFTP 的手机目录',
+    );
     if (selected == null || selected.isEmpty) return false;
     rootPath = selected;
     isMounted = true;

--- a/lib/infrastructure/ssh/sftp_service.dart
+++ b/lib/infrastructure/ssh/sftp_service.dart
@@ -4,6 +4,7 @@ import 'dart:typed_data';
 
 import 'package:dartssh2/dartssh2.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'ssh_service.dart';
@@ -180,9 +181,22 @@ class SftpService extends FileTransferService {
 }
 
 class LocalFileTransferService extends MountableFileTransferService {
-  LocalFileTransferService._(this.rootPath);
+  LocalFileTransferService._(this.rootPath, {this.isMounted = false});
+
+  static const _iosStorageChannel = MethodChannel(
+    'app.netcatty.mobile/storage',
+  );
 
   static Future<LocalFileTransferService> create() async {
+    if (Platform.isIOS) {
+      final mount = await _iosStorageChannel.invokeMapMethod<String, dynamic>(
+        'getMount',
+      );
+      final path = mount?['path']?.toString();
+      if (mount?['mounted'] == true && path?.isNotEmpty == true) {
+        return LocalFileTransferService._(path!, isMounted: true);
+      }
+    }
     final documents = await getApplicationDocumentsDirectory();
     final root = Directory(
       '${documents.path}${Platform.pathSeparator}Netcatty',
@@ -194,7 +208,7 @@ class LocalFileTransferService extends MountableFileTransferService {
   @override
   String rootPath;
   @override
-  bool isMounted = false;
+  bool isMounted;
   @override
   String? get mountedDirectoryName => isMounted
       ? Uri.file(rootPath).pathSegments.where((value) => value.isNotEmpty).last
@@ -209,9 +223,17 @@ class LocalFileTransferService extends MountableFileTransferService {
 
   @override
   Future<bool> mount() async {
-    final selected = await FilePicker.platform.getDirectoryPath(
-      dialogTitle: '选择要挂载到 SFTP 的手机目录',
-    );
+    final String? selected;
+    if (Platform.isIOS) {
+      final mount = await _iosStorageChannel.invokeMapMethod<String, dynamic>(
+        'mount',
+      );
+      selected = mount?['path']?.toString();
+    } else {
+      selected = await FilePicker.platform.getDirectoryPath(
+        dialogTitle: '选择要挂载到 SFTP 的手机目录',
+      );
+    }
     if (selected == null || selected.isEmpty) return false;
     rootPath = selected;
     isMounted = true;

--- a/lib/infrastructure/ssh/terminal_picture_in_picture_service.dart
+++ b/lib/infrastructure/ssh/terminal_picture_in_picture_service.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:flutter/services.dart';
+import 'package:xterm/xterm.dart';
+
+class TerminalPictureInPictureService {
+  const TerminalPictureInPictureService._();
+
+  static const _channel = MethodChannel(
+    'app.netcatty.mobile/picture_in_picture',
+  );
+  static final _stateChanges = StreamController<bool>.broadcast();
+  static var _initialized = false;
+  static var _active = false;
+
+  static bool get active => _active;
+  static Stream<bool> get stateChanges {
+    _initialize();
+    return _stateChanges.stream;
+  }
+
+  static void _initialize() {
+    if (_initialized) return;
+    _initialized = true;
+    _channel.setMethodCallHandler((call) async {
+      if (call.method != 'stateChanged') return;
+      final arguments = call.arguments;
+      final active = arguments is Map && arguments['active'] == true;
+      _setActive(active);
+    });
+  }
+
+  static Future<bool> isSupported() async {
+    _initialize();
+    try {
+      return await _channel.invokeMethod<bool>('isSupported') ?? false;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  static Future<bool> enter({
+    required String title,
+    required String text,
+    required bool connected,
+    required int backgroundColor,
+    required int foregroundColor,
+    required int accentColor,
+  }) async {
+    _initialize();
+    try {
+      final entered = await _channel.invokeMethod<bool>('enter', {
+            'title': title,
+            'text': text,
+            'connected': connected,
+            'backgroundColor': backgroundColor,
+            'foregroundColor': foregroundColor,
+            'accentColor': accentColor,
+            'aspectWidth': 16,
+            'aspectHeight': 9,
+          }) ??
+          false;
+      if (entered) _setActive(true);
+      return entered;
+    } on MissingPluginException {
+      return false;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  static Future<void> update({
+    required String title,
+    required String text,
+    required bool connected,
+    required int backgroundColor,
+    required int foregroundColor,
+    required int accentColor,
+  }) async {
+    if (!_active) return;
+    try {
+      await _channel.invokeMethod<void>('update', {
+        'title': title,
+        'text': text,
+        'connected': connected,
+        'backgroundColor': backgroundColor,
+        'foregroundColor': foregroundColor,
+        'accentColor': accentColor,
+      });
+    } on MissingPluginException {
+      // Picture in Picture is optional outside Android and iOS.
+    } on PlatformException {
+      // A stopped native PiP session may race with the final terminal update.
+    }
+  }
+
+  static Future<void> stop() async {
+    try {
+      await _channel.invokeMethod<void>('stop');
+    } on MissingPluginException {
+      // No-op on unsupported platforms and in widget tests.
+    } on PlatformException {
+      // The system may already have dismissed Picture in Picture.
+    } finally {
+      _setActive(false);
+    }
+  }
+
+  static void _setActive(bool active) {
+    if (_active == active) return;
+    _active = active;
+    _stateChanges.add(active);
+  }
+}
+
+String terminalPictureInPictureText(
+  Terminal terminal, {
+  int maxLines = 18,
+  int maxColumns = 96,
+}) {
+  final buffer = terminal.buffer;
+  if (buffer.lines.length == 0 || maxLines <= 0 || maxColumns <= 0) return '';
+  final scanCount = math.max(buffer.viewHeight, maxLines * 3);
+  final start = math.max(0, buffer.lines.length - scanCount);
+  final result = <String>[];
+  for (var index = start; index < buffer.lines.length; index++) {
+    var text = buffer.lines[index].getText().trimRight();
+    if (text.length > maxColumns) text = text.substring(0, maxColumns);
+    result.add(text);
+  }
+  while (result.isNotEmpty && result.last.isEmpty) {
+    result.removeLast();
+  }
+  if (result.length > maxLines) {
+    result.removeRange(0, result.length - maxLines);
+  }
+  while (result.isNotEmpty && result.first.isEmpty) {
+    result.removeAt(0);
+  }
+  return result.every((line) => line.isEmpty) ? '等待终端输出…' : result.join('\n');
+}

--- a/lib/infrastructure/storage/vault_export_service.dart
+++ b/lib/infrastructure/storage/vault_export_service.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+
+import '../../domain/models/vault.dart';
+
+enum VaultExportResult { saved, cancelled }
+
+typedef SaveVaultFile = Future<String?> Function({
+  String? dialogTitle,
+  String? fileName,
+  FileType type,
+  List<String>? allowedExtensions,
+  Uint8List? bytes,
+});
+
+class VaultExportService {
+  VaultExportService({
+    SaveVaultFile? saveFile,
+    bool? pickerWritesBytes,
+  })  : _saveFile = saveFile ?? FilePicker.platform.saveFile,
+        _pickerWritesBytes =
+            pickerWritesBytes ?? (Platform.isAndroid || Platform.isIOS);
+
+  final SaveVaultFile _saveFile;
+  final bool _pickerWritesBytes;
+
+  Future<VaultExportResult> export(VaultData vault) async {
+    final bytes = Uint8List.fromList(
+      utf8.encode(const JsonEncoder.withIndent('  ').convert(vault.toJson())),
+    );
+    final path = await _saveFile(
+      dialogTitle: '导出 Netcatty 保险库',
+      fileName: 'netcatty-mobile-export.json',
+      type: FileType.custom,
+      allowedExtensions: const ['json'],
+      // Android and iOS document pickers own the selected URI. file_picker
+      // must receive the payload so its native implementation can write it.
+      bytes: _pickerWritesBytes ? bytes : null,
+    );
+    if (path == null) return VaultExportResult.cancelled;
+
+    // Desktop implementations return a normal filesystem destination and do
+    // not write the provided bytes on the application's behalf.
+    if (!_pickerWritesBytes) {
+      await File(path).writeAsBytes(bytes, flush: true);
+    }
+    return VaultExportResult.saved;
+  }
+}

--- a/lib/presentation/home_shell.dart
+++ b/lib/presentation/home_shell.dart
@@ -23,40 +23,56 @@ class HomeShell extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final index = ref.watch(homeTabProvider);
-    return Scaffold(
-      body: IndexedStack(index: index, children: _pages),
-      bottomNavigationBar: NavigationBar(
-        selectedIndex: index,
-        onDestinationSelected: (value) =>
-            ref.read(homeTabProvider.notifier).state = value,
-        destinations: const [
-          NavigationDestination(
-            icon: Icon(Icons.dns_outlined),
-            selectedIcon: Icon(Icons.dns),
-            label: '保险库',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.terminal_outlined),
-            selectedIcon: Icon(Icons.terminal),
-            label: '终端',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.folder_outlined),
-            selectedIcon: Icon(Icons.folder),
-            label: '文件',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.code_outlined),
-            selectedIcon: Icon(Icons.code),
-            label: '片段',
-          ),
-          NavigationDestination(
-            icon: Icon(Icons.settings_outlined),
-            selectedIcon: Icon(Icons.settings),
-            label: '设置',
-          ),
-        ],
+    final terminalFullscreen = ref.watch(terminalFullscreenProvider);
+    final hideNavigation = shouldHideHomeNavigation(index, terminalFullscreen);
+    return PopScope(
+      canPop: !hideNavigation,
+      onPopInvokedWithResult: (didPop, result) {
+        if (!didPop && hideNavigation) {
+          ref.read(terminalFullscreenProvider.notifier).state = false;
+        }
+      },
+      child: Scaffold(
+        body: IndexedStack(index: index, children: _pages),
+        bottomNavigationBar: hideNavigation
+            ? null
+            : NavigationBar(
+                key: const ValueKey('home-navigation-bar'),
+                selectedIndex: index,
+                onDestinationSelected: (value) =>
+                    ref.read(homeTabProvider.notifier).state = value,
+                destinations: const [
+                  NavigationDestination(
+                    icon: Icon(Icons.dns_outlined),
+                    selectedIcon: Icon(Icons.dns),
+                    label: '保险库',
+                  ),
+                  NavigationDestination(
+                    icon: Icon(Icons.terminal_outlined),
+                    selectedIcon: Icon(Icons.terminal),
+                    label: '终端',
+                  ),
+                  NavigationDestination(
+                    icon: Icon(Icons.folder_outlined),
+                    selectedIcon: Icon(Icons.folder),
+                    label: '文件',
+                  ),
+                  NavigationDestination(
+                    icon: Icon(Icons.code_outlined),
+                    selectedIcon: Icon(Icons.code),
+                    label: '片段',
+                  ),
+                  NavigationDestination(
+                    icon: Icon(Icons.settings_outlined),
+                    selectedIcon: Icon(Icons.settings),
+                    label: '设置',
+                  ),
+                ],
+              ),
       ),
     );
   }
 }
+
+bool shouldHideHomeNavigation(int tabIndex, bool terminalFullscreen) =>
+    tabIndex == 1 && terminalFullscreen;

--- a/lib/presentation/home_shell.dart
+++ b/lib/presentation/home_shell.dart
@@ -1,6 +1,9 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../infrastructure/ssh/terminal_picture_in_picture_service.dart';
 import 'screens/settings_screen.dart';
 import 'screens/sftp_screen.dart';
 import 'screens/snippets_screen.dart';
@@ -24,12 +27,22 @@ class HomeShell extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final index = ref.watch(homeTabProvider);
     final terminalFullscreen = ref.watch(terminalFullscreenProvider);
-    final hideNavigation = shouldHideHomeNavigation(index, terminalFullscreen);
+    final terminalPictureInPicture =
+        ref.watch(terminalPictureInPictureProvider);
+    final hideNavigation = shouldHideHomeNavigation(
+      index,
+      terminalFullscreen || terminalPictureInPicture,
+    );
     return PopScope(
       canPop: !hideNavigation,
       onPopInvokedWithResult: (didPop, result) {
         if (!didPop && hideNavigation) {
-          ref.read(terminalFullscreenProvider.notifier).state = false;
+          if (terminalPictureInPicture) {
+            ref.read(terminalPictureInPictureProvider.notifier).state = false;
+            unawaited(TerminalPictureInPictureService.stop());
+          } else {
+            ref.read(terminalFullscreenProvider.notifier).state = false;
+          }
         }
       },
       child: Scaffold(

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -13,6 +13,7 @@ import '../../application/vault_controller.dart';
 import '../../domain/models/settings.dart';
 import '../../domain/models/vault.dart';
 import '../../infrastructure/storage/vault_repository.dart';
+import '../../infrastructure/storage/vault_export_service.dart';
 import '../../infrastructure/sync/cloud_sync_service.dart';
 import '../../infrastructure/sync/github_auth_service.dart';
 import '../theme.dart';
@@ -558,17 +559,13 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   }
 
   Future<void> _export() async {
-    final path = await FilePicker.platform.saveFile(
-      dialogTitle: '导出 Netcatty 保险库',
-      fileName: 'netcatty-mobile-export.json',
-    );
-    if (path == null) return;
     final vault = ref.read(vaultControllerProvider).data ?? VaultData.empty();
-    await File(path).writeAsString(
-      const JsonEncoder.withIndent('  ').convert(vault.toJson()),
-      flush: true,
-    );
-    _message('导出完成');
+    try {
+      final result = await VaultExportService().export(vault);
+      if (result == VaultExportResult.saved) _message('导出完成');
+    } catch (error) {
+      _message('导出失败：$error');
+    }
   }
 
   void _message(String value) {

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -6,6 +6,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../../application/settings_controller.dart';
@@ -27,6 +28,7 @@ class SettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
+  late final Future<PackageInfo> _packageInfo = PackageInfo.fromPlatform();
   final endpoint = TextEditingController();
   final username = TextEditingController();
   final providerSecret = TextEditingController();
@@ -390,9 +392,14 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                 ),
               ),
               const SizedBox(height: 20),
-              const Center(
-                child: Text(
-                  'Netcatty Mobile 1.0.0 · GPL-3.0-or-later',
+              Center(
+                child: FutureBuilder<PackageInfo>(
+                  future: _packageInfo,
+                  builder: (context, snapshot) => Text(
+                    snapshot.hasData
+                        ? 'Netcatty Mobile ${snapshot.data!.version} · GPL-3.0-or-later'
+                        : 'Netcatty Mobile · GPL-3.0-or-later',
+                  ),
                 ),
               ),
             ],

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -283,9 +283,11 @@ class _SftpPaneState extends State<_SftpPane> {
                                 title: Text(source.displayName),
                                 subtitle: Text(
                                   source is MountableFileTransferService
-                                      ? source.isMounted
-                                          ? '已挂载：${source.mountedDirectoryName}'
-                                          : '点文件夹按钮选择手机目录'
+                                      ? source.usesAppDocuments
+                                          ? '文件 App：我的 iPhone/iPad/Netcatty'
+                                          : source.isMounted
+                                              ? '已挂载：${source.mountedDirectoryName}'
+                                              : '点文件夹按钮选择手机目录'
                                       : '已连接 SSH',
                                 ),
                               ),
@@ -356,7 +358,7 @@ class _SftpPaneState extends State<_SftpPane> {
                         !localReady || path == service.rootPath ? null : _up),
                     _toolbar(Icons.refresh, '刷新',
                         _loading || !localReady ? null : refresh),
-                    if (mountable != null)
+                    if (mountable != null && !mountable.usesAppDocuments)
                       _toolbar(
                         Icons.folder_open_outlined,
                         mountable.isMounted ? '更换挂载目录' : '挂载手机目录',
@@ -395,9 +397,11 @@ class _SftpPaneState extends State<_SftpPane> {
                         child: Text(
                           mountable != null && !mountable.isMounted
                               ? '尚未挂载手机目录\n点上方文件夹按钮选择目录'
-                              : service.isLocal
-                                  ? '挂载目录为空\n可直接上传或导入文件'
-                                  : '目录为空',
+                              : mountable?.usesAppDocuments == true
+                                  ? 'Netcatty 文件夹为空\n可从服务器下载或导入文件'
+                                  : service.isLocal
+                                      ? '挂载目录为空\n可直接上传或导入文件'
+                                      : '目录为空',
                           textAlign: TextAlign.center,
                           style: const TextStyle(fontSize: 11),
                         ),

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -16,6 +16,8 @@ import '../widgets/server_monitor_sheet.dart';
 import '../widgets/terminal_special_keys.dart';
 import '../widgets/system_management/system_management_sheet.dart';
 
+final terminalFullscreenProvider = StateProvider<bool>((ref) => false);
+
 class TerminalScreen extends ConsumerStatefulWidget {
   const TerminalScreen({super.key});
 
@@ -34,228 +36,283 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
         ref.watch(vaultControllerProvider).data?.snippets ?? const [];
     final selectedPending = state.selectedPending;
     final visibleSession = selectedPending == null ? state.active : null;
+    final fullscreen = ref.watch(terminalFullscreenProvider);
+    if (fullscreen && visibleSession == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && ref.read(terminalFullscreenProvider)) {
+          ref.read(terminalFullscreenProvider.notifier).state = false;
+        }
+      });
+    }
     final tabHosts = [
       ...state.sessions.map((value) => value.host),
       ...state.pendingConnections.map((value) => value.host),
     ];
     return SafeArea(
-      child: Column(
+      child: Stack(
         children: [
-          SizedBox(
-            height: 52,
-            child: Row(
+          Positioned.fill(
+            child: Column(
               children: [
-                const SizedBox(width: 12),
-                Icon(
-                  Icons.terminal,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
-                const SizedBox(width: 8),
-                Expanded(
-                  child: state.tabCount == 0
-                      ? const Text('终端')
-                      : ListView.builder(
-                          scrollDirection: Axis.horizontal,
-                          itemCount: state.tabCount,
-                          itemBuilder: (_, index) {
-                            final host = tabHosts[index];
-                            final occurrence = tabHosts
-                                .take(index + 1)
-                                .where((value) => value.id == host.id)
-                                .length;
-                            final duplicateCount = tabHosts
-                                .where((value) => value.id == host.id)
-                                .length;
-                            if (index >= state.sessions.length) {
-                              final pending = state.pendingConnections[
-                                  index - state.sessions.length];
-                              final failed = pending.phase ==
-                                  PendingConnectionPhase.failed;
-                              return Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 7,
-                                  horizontal: 2,
-                                ),
-                                child: InputChip(
-                                  selected: state.activePendingId == pending.id,
-                                  showCheckmark: false,
-                                  avatar: failed
-                                      ? const Icon(
-                                          Icons.error_outline,
-                                          size: 17,
-                                          color: Colors.redAccent,
-                                        )
-                                      : const SizedBox.square(
-                                          dimension: 14,
-                                          child: CircularProgressIndicator(
-                                            strokeWidth: 2,
-                                          ),
-                                        ),
-                                  label: Text(
-                                    duplicateCount > 1
-                                        ? '${host.label} #$occurrence'
-                                        : host.label,
-                                  ),
-                                  onPressed: () => ref
-                                      .read(
-                                        sessionControllerProvider.notifier,
-                                      )
-                                      .activate(index),
-                                  onDeleted: failed
-                                      ? () => ref
-                                          .read(
-                                            sessionControllerProvider.notifier,
-                                          )
-                                          .dismissPending(pending.id)
-                                      : null,
-                                ),
-                              );
-                            }
-                            final session = state.sessions[index];
-                            return Padding(
-                              padding: const EdgeInsets.symmetric(
-                                vertical: 7,
-                                horizontal: 2,
-                              ),
-                              child: InputChip(
-                                selected: state.activeIndex == index,
-                                showCheckmark: false,
-                                avatar: Icon(
-                                  session.connected
-                                      ? Icons.circle
-                                      : Icons.error_outline,
-                                  size: session.connected ? 10 : 16,
-                                  color: session.connected
-                                      ? Colors.greenAccent
-                                      : Colors.orangeAccent,
-                                ),
-                                label: Text(
-                                  duplicateCount > 1
-                                      ? '${session.host.label} #$occurrence'
-                                      : session.host.label,
-                                ),
-                                onPressed: () => ref
-                                    .read(sessionControllerProvider.notifier)
-                                    .activate(index),
-                                onDeleted: () => _confirmClose(index, session),
-                              ),
-                            );
-                          },
+                if (!fullscreen)
+                  SizedBox(
+                    key: const ValueKey('terminal-tab-strip'),
+                    height: 52,
+                    child: Row(
+                      children: [
+                        const SizedBox(width: 12),
+                        Icon(
+                          Icons.terminal,
+                          color: Theme.of(context).colorScheme.primary,
                         ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: state.tabCount == 0
+                              ? const Text('终端')
+                              : ListView.builder(
+                                  scrollDirection: Axis.horizontal,
+                                  itemCount: state.tabCount,
+                                  itemBuilder: (_, index) {
+                                    final host = tabHosts[index];
+                                    final occurrence = tabHosts
+                                        .take(index + 1)
+                                        .where((value) => value.id == host.id)
+                                        .length;
+                                    final duplicateCount = tabHosts
+                                        .where((value) => value.id == host.id)
+                                        .length;
+                                    if (index >= state.sessions.length) {
+                                      final pending = state.pendingConnections[
+                                          index - state.sessions.length];
+                                      final failed = pending.phase ==
+                                          PendingConnectionPhase.failed;
+                                      return Padding(
+                                        padding: const EdgeInsets.symmetric(
+                                          vertical: 7,
+                                          horizontal: 2,
+                                        ),
+                                        child: InputChip(
+                                          selected: state.activePendingId ==
+                                              pending.id,
+                                          showCheckmark: false,
+                                          avatar: failed
+                                              ? const Icon(
+                                                  Icons.error_outline,
+                                                  size: 17,
+                                                  color: Colors.redAccent,
+                                                )
+                                              : const SizedBox.square(
+                                                  dimension: 14,
+                                                  child:
+                                                      CircularProgressIndicator(
+                                                    strokeWidth: 2,
+                                                  ),
+                                                ),
+                                          label: Text(
+                                            duplicateCount > 1
+                                                ? '${host.label} #$occurrence'
+                                                : host.label,
+                                          ),
+                                          onPressed: () => ref
+                                              .read(
+                                                sessionControllerProvider
+                                                    .notifier,
+                                              )
+                                              .activate(index),
+                                          onDeleted: failed
+                                              ? () => ref
+                                                  .read(
+                                                    sessionControllerProvider
+                                                        .notifier,
+                                                  )
+                                                  .dismissPending(pending.id)
+                                              : null,
+                                        ),
+                                      );
+                                    }
+                                    final session = state.sessions[index];
+                                    return Padding(
+                                      padding: const EdgeInsets.symmetric(
+                                        vertical: 7,
+                                        horizontal: 2,
+                                      ),
+                                      child: InputChip(
+                                        selected: state.activeIndex == index,
+                                        showCheckmark: false,
+                                        avatar: Icon(
+                                          session.connected
+                                              ? Icons.circle
+                                              : Icons.error_outline,
+                                          size: session.connected ? 10 : 16,
+                                          color: session.connected
+                                              ? Colors.greenAccent
+                                              : Colors.orangeAccent,
+                                        ),
+                                        label: Text(
+                                          duplicateCount > 1
+                                              ? '${session.host.label} #$occurrence'
+                                              : session.host.label,
+                                        ),
+                                        onPressed: () => ref
+                                            .read(sessionControllerProvider
+                                                .notifier)
+                                            .activate(index),
+                                        onDeleted: () =>
+                                            _confirmClose(index, session),
+                                      ),
+                                    );
+                                  },
+                                ),
+                        ),
+                        if (visibleSession != null)
+                          IconButton(
+                            key: const ValueKey(
+                              'terminal-performance-monitor',
+                            ),
+                            tooltip: '性能监控',
+                            onPressed: visibleSession.isSsh
+                                ? () => _openPerformanceMonitor(visibleSession)
+                                : null,
+                            icon: const Icon(Icons.monitor_heart_outlined),
+                          ),
+                      ],
+                    ),
+                  ),
+                Expanded(
+                  child: selectedPending != null
+                      ? _ConnectionStatusPane(
+                          pending: selectedPending,
+                          onReturn: state.sessions.isEmpty
+                              ? null
+                              : () => ref
+                                  .read(sessionControllerProvider.notifier)
+                                  .activate(state.activeIndex),
+                          onClose: selectedPending.phase ==
+                                  PendingConnectionPhase.failed
+                              ? () => ref
+                                  .read(sessionControllerProvider.notifier)
+                                  .dismissPending(selectedPending.id)
+                              : null,
+                        )
+                      : state.sessions.isEmpty
+                          ? const EmptyState(
+                              icon: Icons.terminal_outlined,
+                              title: '没有活动会话',
+                              subtitle: '从“保险库”选择主机开始连接。',
+                            )
+                          : LayoutBuilder(
+                              builder: (context, constraints) {
+                                if (!_split || state.sessions.length < 2) {
+                                  return _TerminalPane(
+                                    key: ValueKey(state.active!.id),
+                                    session: state.active!,
+                                    fontSize: settings.terminalFontSize,
+                                  );
+                                }
+                                final secondIndex = (state.activeIndex + 1) %
+                                    state.sessions.length;
+                                final children = [
+                                  Expanded(
+                                    child: _TerminalPane(
+                                      key: ValueKey(state.active!.id),
+                                      session: state.active!,
+                                      fontSize: settings.terminalFontSize,
+                                    ),
+                                  ),
+                                  const Divider(height: 1, thickness: 1),
+                                  Expanded(
+                                    child: _TerminalPane(
+                                      key: ValueKey(
+                                          state.sessions[secondIndex].id),
+                                      session: state.sessions[secondIndex],
+                                      fontSize: settings.terminalFontSize,
+                                    ),
+                                  ),
+                                ];
+                                return constraints.maxWidth >
+                                        constraints.maxHeight
+                                    ? Row(children: children)
+                                    : Column(children: children);
+                              },
+                            ),
                 ),
                 if (visibleSession != null)
-                  IconButton(
-                    tooltip: '性能监控',
-                    onPressed: visibleSession.isSsh
+                  TerminalSpecialKeys(
+                    order: settings.terminalQuickKeys,
+                    customKeys: settings.terminalCustomKeys,
+                    onSend: ref.read(sessionControllerProvider.notifier).send,
+                    onAi: () => _openAi(visibleSession),
+                    onPortForward: visibleSession.isSsh
+                        ? () => showModalBottomSheet<void>(
+                              context: context,
+                              isScrollControlled: true,
+                              builder: (_) =>
+                                  PortForwardSheet(session: visibleSession),
+                            )
+                        : null,
+                    onSystemManagement: visibleSession.isSsh
                         ? () => showModalBottomSheet<void>(
                               context: context,
                               useSafeArea: true,
                               isScrollControlled: true,
-                              builder: (_) => ServerMonitorSheet(
+                              backgroundColor: Colors.transparent,
+                              builder: (_) => SystemManagementSheet(
                                 session: visibleSession,
+                                snippets: snippets,
+                                onOpenTerminal: (label, command) =>
+                                    _openManagedTerminal(
+                                  visibleSession,
+                                  label,
+                                  command,
+                                ),
                               ),
                             )
                         : null,
-                    icon: const Icon(Icons.monitor_heart_outlined),
+                    fullscreen: fullscreen,
+                    onFullscreen: () => ref
+                        .read(terminalFullscreenProvider.notifier)
+                        .state = !fullscreen,
+                    split: _split,
+                    onSplit: state.sessions.length > 1
+                        ? () => setState(() => _split = !_split)
+                        : null,
                   ),
               ],
             ),
           ),
-          Expanded(
-            child: selectedPending != null
-                ? _ConnectionStatusPane(
-                    pending: selectedPending,
-                    onReturn: state.sessions.isEmpty
-                        ? null
-                        : () => ref
-                            .read(sessionControllerProvider.notifier)
-                            .activate(state.activeIndex),
-                    onClose:
-                        selectedPending.phase == PendingConnectionPhase.failed
-                            ? () => ref
-                                .read(sessionControllerProvider.notifier)
-                                .dismissPending(selectedPending.id)
-                            : null,
-                  )
-                : state.sessions.isEmpty
-                    ? const EmptyState(
-                        icon: Icons.terminal_outlined,
-                        title: '没有活动会话',
-                        subtitle: '从“保险库”选择主机开始连接。',
-                      )
-                    : LayoutBuilder(
-                        builder: (context, constraints) {
-                          if (!_split || state.sessions.length < 2) {
-                            return _TerminalPane(
-                              key: ValueKey(state.active!.id),
-                              session: state.active!,
-                              fontSize: settings.terminalFontSize,
-                            );
-                          }
-                          final secondIndex =
-                              (state.activeIndex + 1) % state.sessions.length;
-                          final children = [
-                            Expanded(
-                              child: _TerminalPane(
-                                key: ValueKey(state.active!.id),
-                                session: state.active!,
-                                fontSize: settings.terminalFontSize,
-                              ),
-                            ),
-                            const Divider(height: 1, thickness: 1),
-                            Expanded(
-                              child: _TerminalPane(
-                                key: ValueKey(state.sessions[secondIndex].id),
-                                session: state.sessions[secondIndex],
-                                fontSize: settings.terminalFontSize,
-                              ),
-                            ),
-                          ];
-                          return constraints.maxWidth > constraints.maxHeight
-                              ? Row(children: children)
-                              : Column(children: children);
-                        },
-                      ),
-          ),
-          if (visibleSession != null)
-            TerminalSpecialKeys(
-              order: settings.terminalQuickKeys,
-              customKeys: settings.terminalCustomKeys,
-              onSend: ref.read(sessionControllerProvider.notifier).send,
-              onAi: () => _openAi(visibleSession),
-              onPortForward: visibleSession.isSsh
-                  ? () => showModalBottomSheet<void>(
-                        context: context,
-                        isScrollControlled: true,
-                        builder: (_) =>
-                            PortForwardSheet(session: visibleSession),
-                      )
-                  : null,
-              onSystemManagement: visibleSession.isSsh
-                  ? () => showModalBottomSheet<void>(
-                        context: context,
-                        useSafeArea: true,
-                        isScrollControlled: true,
-                        backgroundColor: Colors.transparent,
-                        builder: (_) => SystemManagementSheet(
-                          session: visibleSession,
-                          snippets: snippets,
-                          onOpenTerminal: (label, command) =>
-                              _openManagedTerminal(
-                            visibleSession,
-                            label,
-                            command,
-                          ),
-                        ),
-                      )
-                  : null,
-              split: _split,
-              onSplit: state.sessions.length > 1
-                  ? () => setState(() => _split = !_split)
-                  : null,
+          if (fullscreen && visibleSession != null)
+            Positioned(
+              top: 4,
+              right: 4,
+              child: Material(
+                key: const ValueKey('terminal-floating-performance'),
+                color: Theme.of(context)
+                    .colorScheme
+                    .surfaceContainerHighest
+                    .withValues(alpha: .82),
+                elevation: 2,
+                shape: const CircleBorder(),
+                child: IconButton(
+                  key: const ValueKey('terminal-performance-monitor'),
+                  tooltip: '性能监控',
+                  onPressed: visibleSession.isSsh
+                      ? () => _openPerformanceMonitor(visibleSession)
+                      : null,
+                  icon: const Icon(Icons.monitor_heart_outlined),
+                ),
+              ),
             ),
         ],
       ),
+    );
+  }
+
+  void _openPerformanceMonitor(ActiveTerminalSession session) {
+    showModalBottomSheet<void>(
+      context: context,
+      useSafeArea: true,
+      isScrollControlled: true,
+      builder: (_) => ServerMonitorSheet(session: session),
     );
   }
 

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
@@ -8,6 +10,7 @@ import '../../application/settings_controller.dart';
 import '../../application/vault_controller.dart';
 import '../../infrastructure/ai/ai_service.dart';
 import '../../infrastructure/ssh/ssh_service.dart';
+import '../../infrastructure/ssh/terminal_picture_in_picture_service.dart';
 import '../../infrastructure/storage/vault_repository.dart';
 import '../widgets/empty_state.dart';
 import '../widgets/host_system_icon.dart';
@@ -17,6 +20,7 @@ import '../widgets/terminal_special_keys.dart';
 import '../widgets/system_management/system_management_sheet.dart';
 
 final terminalFullscreenProvider = StateProvider<bool>((ref) => false);
+final terminalPictureInPictureProvider = StateProvider<bool>((ref) => false);
 
 class TerminalScreen extends ConsumerStatefulWidget {
   const TerminalScreen({super.key});
@@ -27,6 +31,23 @@ class TerminalScreen extends ConsumerStatefulWidget {
 
 class _TerminalScreenState extends ConsumerState<TerminalScreen> {
   var _split = false;
+  StreamSubscription<bool>? _pictureInPictureSubscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _pictureInPictureSubscription =
+        TerminalPictureInPictureService.stateChanges.listen((active) {
+      if (!mounted) return;
+      ref.read(terminalPictureInPictureProvider.notifier).state = active;
+    });
+  }
+
+  @override
+  void dispose() {
+    _pictureInPictureSubscription?.cancel();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -37,10 +58,16 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
     final selectedPending = state.selectedPending;
     final visibleSession = selectedPending == null ? state.active : null;
     final fullscreen = ref.watch(terminalFullscreenProvider);
-    if (fullscreen && visibleSession == null) {
+    final pictureInPicture = ref.watch(terminalPictureInPictureProvider);
+    if ((fullscreen || pictureInPicture) && visibleSession == null) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && ref.read(terminalFullscreenProvider)) {
+        if (!mounted) return;
+        if (ref.read(terminalFullscreenProvider)) {
           ref.read(terminalFullscreenProvider.notifier).state = false;
+        }
+        if (ref.read(terminalPictureInPictureProvider)) {
+          ref.read(terminalPictureInPictureProvider.notifier).state = false;
+          unawaited(TerminalPictureInPictureService.stop());
         }
       });
     }
@@ -54,7 +81,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
           Positioned.fill(
             child: Column(
               children: [
-                if (!fullscreen)
+                if (!fullscreen && !pictureInPicture)
                   SizedBox(
                     key: const ValueKey('terminal-tab-strip'),
                     height: 52,
@@ -178,6 +205,8 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
                       ],
                     ),
                   ),
+                if (pictureInPicture && visibleSession != null)
+                  _TerminalPictureInPictureHeader(session: visibleSession),
                 Expanded(
                   child: selectedPending != null
                       ? _ConnectionStatusPane(
@@ -202,11 +231,14 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
                             )
                           : LayoutBuilder(
                               builder: (context, constraints) {
-                                if (!_split || state.sessions.length < 2) {
+                                if (pictureInPicture ||
+                                    !_split ||
+                                    state.sessions.length < 2) {
                                   return _TerminalPane(
                                     key: ValueKey(state.active!.id),
                                     session: state.active!,
                                     fontSize: settings.terminalFontSize,
+                                    pictureInPicture: pictureInPicture,
                                   );
                                 }
                                 final secondIndex = (state.activeIndex + 1) %
@@ -217,6 +249,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
                                       key: ValueKey(state.active!.id),
                                       session: state.active!,
                                       fontSize: settings.terminalFontSize,
+                                      pictureInPicture: false,
                                     ),
                                   ),
                                   const Divider(height: 1, thickness: 1),
@@ -226,6 +259,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
                                           state.sessions[secondIndex].id),
                                       session: state.sessions[secondIndex],
                                       fontSize: settings.terminalFontSize,
+                                      pictureInPicture: false,
                                     ),
                                   ),
                                 ];
@@ -236,7 +270,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
                               },
                             ),
                 ),
-                if (visibleSession != null)
+                if (visibleSession != null && !pictureInPicture)
                   TerminalSpecialKeys(
                     order: settings.terminalQuickKeys,
                     customKeys: settings.terminalCustomKeys,
@@ -268,6 +302,9 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
                               ),
                             )
                         : null,
+                    pictureInPicture: pictureInPicture,
+                    onPictureInPicture: () =>
+                        _togglePictureInPicture(visibleSession),
                     fullscreen: fullscreen,
                     onFullscreen: () => ref
                         .read(terminalFullscreenProvider.notifier)
@@ -280,7 +317,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
               ],
             ),
           ),
-          if (fullscreen && visibleSession != null)
+          if (fullscreen && !pictureInPicture && visibleSession != null)
             Positioned(
               top: 4,
               right: 4,
@@ -304,6 +341,40 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
             ),
         ],
       ),
+    );
+  }
+
+  Future<void> _togglePictureInPicture(
+    ActiveTerminalSession session,
+  ) async {
+    if (ref.read(terminalPictureInPictureProvider)) {
+      await TerminalPictureInPictureService.stop();
+      return;
+    }
+    final supported = await TerminalPictureInPictureService.isSupported();
+    if (!supported) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('当前设备或系统版本不支持终端画中画')),
+      );
+      return;
+    }
+    ref.read(terminalPictureInPictureProvider.notifier).state = true;
+    await WidgetsBinding.instance.endOfFrame;
+    if (!mounted) return;
+    final scheme = Theme.of(context).colorScheme;
+    final entered = await TerminalPictureInPictureService.enter(
+      title: session.host.label,
+      text: terminalPictureInPictureText(session.terminal),
+      connected: session.connected,
+      backgroundColor: scheme.surface.toARGB32(),
+      foregroundColor: scheme.onSurface.toARGB32(),
+      accentColor: scheme.primary.toARGB32(),
+    );
+    if (entered || !mounted) return;
+    ref.read(terminalPictureInPictureProvider.notifier).state = false;
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('无法启动画中画，请检查系统画中画权限')),
     );
   }
 
@@ -585,14 +656,54 @@ class _ConnectionStatusPane extends StatelessWidget {
   }
 }
 
+class _TerminalPictureInPictureHeader extends StatelessWidget {
+  const _TerminalPictureInPictureHeader({required this.session});
+
+  final ActiveTerminalSession session;
+
+  @override
+  Widget build(BuildContext context) => ColoredBox(
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
+        child: SizedBox(
+          height: 30,
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 10),
+            child: Row(
+              children: [
+                Icon(
+                  Icons.circle,
+                  size: 8,
+                  color: session.connected
+                      ? Colors.greenAccent
+                      : Colors.orangeAccent,
+                ),
+                const SizedBox(width: 7),
+                Expanded(
+                  child: Text(
+                    session.host.label,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.labelMedium,
+                  ),
+                ),
+                const Icon(Icons.picture_in_picture, size: 15),
+              ],
+            ),
+          ),
+        ),
+      );
+}
+
 class _TerminalPane extends StatefulWidget {
   const _TerminalPane({
     super.key,
     required this.session,
     required this.fontSize,
+    required this.pictureInPicture,
   });
   final ActiveTerminalSession session;
   final double fontSize;
+  final bool pictureInPicture;
 
   @override
   State<_TerminalPane> createState() => _TerminalPaneState();
@@ -604,12 +715,67 @@ class _TerminalPaneState extends State<_TerminalPane> {
   final _terminalStackKey = GlobalKey();
   final _scrollController = ScrollController();
   Offset? _dragPointerToAnchor;
+  Timer? _pictureInPictureUpdateTimer;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.session.terminal.addListener(_onTerminalChanged);
+    if (widget.pictureInPicture) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _sendPipUpdate());
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant _TerminalPane oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.session.terminal != widget.session.terminal) {
+      oldWidget.session.terminal.removeListener(_onTerminalChanged);
+      widget.session.terminal.addListener(_onTerminalChanged);
+    }
+    if (!oldWidget.pictureInPicture && widget.pictureInPicture) {
+      WidgetsBinding.instance.addPostFrameCallback((_) => _sendPipUpdate());
+    } else if (oldWidget.pictureInPicture && !widget.pictureInPicture) {
+      _pictureInPictureUpdateTimer?.cancel();
+      _pictureInPictureUpdateTimer = null;
+    }
+  }
 
   @override
   void dispose() {
+    widget.session.terminal.removeListener(_onTerminalChanged);
+    _pictureInPictureUpdateTimer?.cancel();
     _controller.dispose();
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _onTerminalChanged() {
+    if (!widget.pictureInPicture || _pictureInPictureUpdateTimer != null) {
+      return;
+    }
+    _pictureInPictureUpdateTimer = Timer(
+      const Duration(milliseconds: 350),
+      () {
+        _pictureInPictureUpdateTimer = null;
+        _sendPipUpdate();
+      },
+    );
+  }
+
+  void _sendPipUpdate() {
+    if (!mounted || !widget.pictureInPicture) return;
+    final scheme = Theme.of(context).colorScheme;
+    unawaited(
+      TerminalPictureInPictureService.update(
+        title: widget.session.host.label,
+        text: terminalPictureInPictureText(widget.session.terminal),
+        connected: widget.session.connected,
+        backgroundColor: scheme.surface.toARGB32(),
+        foregroundColor: scheme.onSurface.toARGB32(),
+        accentColor: scheme.primary.toARGB32(),
+      ),
+    );
   }
 
   @override
@@ -664,14 +830,14 @@ class _TerminalPaneState extends State<_TerminalPane> {
                 scrollController: _scrollController,
                 theme: terminalTheme,
                 keyboardAppearance: Theme.of(context).brightness,
-                autofocus: true,
+                autofocus: !widget.pictureInPicture,
                 padding: const EdgeInsets.all(8),
                 textStyle: TerminalStyle(
                   fontSize: widget.fontSize,
                   fontFamily: 'monospace',
                 ),
               ),
-              if (startHandle != null)
+              if (!widget.pictureInPicture && startHandle != null)
                 _TerminalSelectionHandle(
                   key: const ValueKey('terminal-selection-handle-start'),
                   anchor: startHandle,
@@ -680,7 +846,7 @@ class _TerminalPaneState extends State<_TerminalPane> {
                   onPanUpdate: (details) => _updateHandleDrag(true, details),
                   onPanEnd: _endHandleDrag,
                 ),
-              if (endHandle != null)
+              if (!widget.pictureInPicture && endHandle != null)
                 _TerminalSelectionHandle(
                   key: const ValueKey('terminal-selection-handle-end'),
                   anchor: endHandle,
@@ -689,7 +855,7 @@ class _TerminalPaneState extends State<_TerminalPane> {
                   onPanUpdate: (details) => _updateHandleDrag(false, details),
                   onPanEnd: _endHandleDrag,
                 ),
-              if (selection != null)
+              if (!widget.pictureInPicture && selection != null)
                 Positioned(
                   top: 10,
                   right: 10,

--- a/lib/presentation/widgets/terminal_special_keys.dart
+++ b/lib/presentation/widgets/terminal_special_keys.dart
@@ -14,6 +14,8 @@ class TerminalSpecialKeys extends ConsumerStatefulWidget {
     required this.onAi,
     required this.onPortForward,
     required this.onSystemManagement,
+    required this.fullscreen,
+    required this.onFullscreen,
     required this.split,
     required this.onSplit,
   });
@@ -24,6 +26,8 @@ class TerminalSpecialKeys extends ConsumerStatefulWidget {
   final VoidCallback onAi;
   final VoidCallback? onPortForward;
   final VoidCallback? onSystemManagement;
+  final bool fullscreen;
+  final VoidCallback onFullscreen;
   final bool split;
   final VoidCallback? onSplit;
 
@@ -88,6 +92,7 @@ class _TerminalSpecialKeysState extends ConsumerState<TerminalSpecialKeys> {
               children: [
                 IconButton(
                   key: const ValueKey('terminal-action-ai'),
+                  visualDensity: VisualDensity.compact,
                   tooltip: 'Catty Agent',
                   onPressed: widget.onAi,
                   icon: Icon(
@@ -97,18 +102,33 @@ class _TerminalSpecialKeysState extends ConsumerState<TerminalSpecialKeys> {
                 ),
                 IconButton(
                   key: const ValueKey('terminal-action-port-forward'),
+                  visualDensity: VisualDensity.compact,
                   tooltip: '端口转发',
                   onPressed: widget.onPortForward,
                   icon: const Icon(Icons.swap_horiz),
                 ),
                 IconButton(
                   key: const ValueKey('terminal-action-system-management'),
+                  visualDensity: VisualDensity.compact,
                   tooltip: '系统管理',
                   onPressed: widget.onSystemManagement,
                   icon: const Icon(Icons.admin_panel_settings_outlined),
                 ),
                 IconButton(
+                  key: const ValueKey('terminal-action-fullscreen'),
+                  visualDensity: VisualDensity.compact,
+                  tooltip: widget.fullscreen ? '退出全屏' : '全屏',
+                  isSelected: widget.fullscreen,
+                  onPressed: widget.onFullscreen,
+                  icon: Icon(
+                    widget.fullscreen
+                        ? Icons.fullscreen_exit
+                        : Icons.fullscreen,
+                  ),
+                ),
+                IconButton(
                   key: const ValueKey('terminal-action-split'),
+                  visualDensity: VisualDensity.compact,
                   tooltip: '分屏',
                   isSelected: widget.split,
                   onPressed: widget.onSplit,
@@ -116,12 +136,14 @@ class _TerminalSpecialKeysState extends ConsumerState<TerminalSpecialKeys> {
                 ),
                 IconButton(
                   key: const ValueKey('terminal-action-edit'),
+                  visualDensity: VisualDensity.compact,
                   tooltip: '编辑快捷键',
                   onPressed: () => _customize(context, normalized),
                   icon: const Icon(Icons.tune, size: 20),
                 ),
                 IconButton(
                   key: const ValueKey('terminal-action-hide-keyboard'),
+                  visualDensity: VisualDensity.compact,
                   tooltip: '收起键盘',
                   onPressed: () =>
                       FocusManager.instance.primaryFocus?.unfocus(),

--- a/lib/presentation/widgets/terminal_special_keys.dart
+++ b/lib/presentation/widgets/terminal_special_keys.dart
@@ -14,6 +14,8 @@ class TerminalSpecialKeys extends ConsumerStatefulWidget {
     required this.onAi,
     required this.onPortForward,
     required this.onSystemManagement,
+    required this.pictureInPicture,
+    required this.onPictureInPicture,
     required this.fullscreen,
     required this.onFullscreen,
     required this.split,
@@ -26,6 +28,8 @@ class TerminalSpecialKeys extends ConsumerStatefulWidget {
   final VoidCallback onAi;
   final VoidCallback? onPortForward;
   final VoidCallback? onSystemManagement;
+  final bool pictureInPicture;
+  final VoidCallback? onPictureInPicture;
   final bool fullscreen;
   final VoidCallback onFullscreen;
   final bool split;
@@ -113,6 +117,18 @@ class _TerminalSpecialKeysState extends ConsumerState<TerminalSpecialKeys> {
                   tooltip: '系统管理',
                   onPressed: widget.onSystemManagement,
                   icon: const Icon(Icons.admin_panel_settings_outlined),
+                ),
+                IconButton(
+                  key: const ValueKey('terminal-action-picture-in-picture'),
+                  visualDensity: VisualDensity.compact,
+                  tooltip: widget.pictureInPicture ? '退出画中画' : '画中画',
+                  isSelected: widget.pictureInPicture,
+                  onPressed: widget.onPictureInPicture,
+                  icon: Icon(
+                    widget.pictureInPicture
+                        ? Icons.picture_in_picture_alt
+                        : Icons.picture_in_picture,
+                  ),
                 ),
                 IconButton(
                   key: const ValueKey('terminal-action-fullscreen'),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -429,6 +429,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: "468c26b4254ab01979fa5e4a98cb343ea3631b9acee6f21028997419a80e1a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.0.1"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "202a487f08836a592a6bd4f901ac69b3a8f146af552bbd14407b6b41e1c3f086"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
   path:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: netcatty_mobile
 description: Netcatty mobile SSH, SFTP and cloud-sync client for Android and iOS.
 publish_to: none
-version: 1.2.0+2
+version: 1.2.1+3
 
 environment:
   sdk: ">=3.4.0 <4.0.0"
@@ -23,6 +23,7 @@ dependencies:
   uuid: ^4.5.1
   file_picker: ^10.2.0
   path_provider: ^2.1.5
+  package_info_plus: ^9.0.1
   share_plus: ^11.0.0
   url_launcher: ^6.3.2
   intl: ^0.20.2

--- a/test/sftp_terminal_usability_test.dart
+++ b/test/sftp_terminal_usability_test.dart
@@ -5,8 +5,10 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:netcatty_mobile/domain/models/settings.dart';
 import 'package:netcatty_mobile/infrastructure/ssh/sftp_service.dart';
+import 'package:netcatty_mobile/infrastructure/ssh/terminal_picture_in_picture_service.dart';
 import 'package:netcatty_mobile/presentation/home_shell.dart';
 import 'package:netcatty_mobile/presentation/widgets/terminal_special_keys.dart';
+import 'package:xterm/xterm.dart';
 
 void main() {
   test('home navigation only hides for a fullscreen terminal', () {
@@ -109,6 +111,8 @@ void main() {
                   onAi: _ignore,
                   onPortForward: null,
                   onSystemManagement: null,
+                  pictureInPicture: false,
+                  onPictureInPicture: _ignore,
                   fullscreen: false,
                   onFullscreen: _ignore,
                   split: false,
@@ -142,6 +146,7 @@ void main() {
       'terminal-action-ai',
       'terminal-action-port-forward',
       'terminal-action-system-management',
+      'terminal-action-picture-in-picture',
       'terminal-action-fullscreen',
       'terminal-action-split',
       'terminal-action-edit',
@@ -172,6 +177,17 @@ void main() {
       findsNothing,
     );
     expect(find.byTooltip('全屏'), findsOneWidget);
+    expect(find.byTooltip('画中画'), findsOneWidget);
+  });
+
+  test('terminal PiP text keeps only the most recent visible lines', () {
+    final terminal = Terminal(maxLines: 100);
+    terminal.write('one\r\ntwo\r\nthree\r\nfour');
+
+    expect(
+      terminalPictureInPictureText(terminal, maxLines: 3),
+      'two\nthree\nfour',
+    );
   });
 }
 

--- a/test/sftp_terminal_usability_test.dart
+++ b/test/sftp_terminal_usability_test.dart
@@ -5,9 +5,16 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:netcatty_mobile/domain/models/settings.dart';
 import 'package:netcatty_mobile/infrastructure/ssh/sftp_service.dart';
+import 'package:netcatty_mobile/presentation/home_shell.dart';
 import 'package:netcatty_mobile/presentation/widgets/terminal_special_keys.dart';
 
 void main() {
+  test('home navigation only hides for a fullscreen terminal', () {
+    expect(shouldHideHomeNavigation(1, true), isTrue);
+    expect(shouldHideHomeNavigation(1, false), isFalse);
+    expect(shouldHideHomeNavigation(2, true), isFalse);
+  });
+
   test('legacy default quick keys migrate to the new mobile defaults', () {
     final settings = AppSettings.fromJson({
       'terminalQuickKeys': legacyDefaultTerminalQuickKeys,
@@ -102,6 +109,8 @@ void main() {
                   onAi: _ignore,
                   onPortForward: null,
                   onSystemManagement: null,
+                  fullscreen: false,
+                  onFullscreen: _ignore,
                   split: false,
                   onSplit: null,
                 ),
@@ -133,6 +142,7 @@ void main() {
       'terminal-action-ai',
       'terminal-action-port-forward',
       'terminal-action-system-management',
+      'terminal-action-fullscreen',
       'terminal-action-split',
       'terminal-action-edit',
       'terminal-action-hide-keyboard',
@@ -161,6 +171,7 @@ void main() {
       ),
       findsNothing,
     );
+    expect(find.byTooltip('全屏'), findsOneWidget);
   });
 }
 

--- a/test/terminal_connection_dialog_test.dart
+++ b/test/terminal_connection_dialog_test.dart
@@ -128,6 +128,29 @@ void main() {
         find.byKey(const ValueKey('copy-terminal-selection')),
         findsOneWidget,
       );
+
+      expect(
+        find.byKey(const ValueKey('terminal-tab-strip')),
+        findsOneWidget,
+      );
+      await tester.tap(
+        find.byKey(const ValueKey('terminal-action-fullscreen')),
+      );
+      await tester.pump();
+
+      expect(
+        find.byKey(const ValueKey('terminal-tab-strip')),
+        findsNothing,
+      );
+      expect(
+        find.byKey(const ValueKey('terminal-floating-performance')),
+        findsOneWidget,
+      );
+      expect(
+        find.byKey(const ValueKey('terminal-performance-monitor')),
+        findsOneWidget,
+      );
+      expect(find.byTooltip('退出全屏'), findsOneWidget);
     },
   );
 }

--- a/test/vault_export_service_test.dart
+++ b/test/vault_export_service_test.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netcatty_mobile/domain/models/vault.dart';
+import 'package:netcatty_mobile/infrastructure/storage/vault_export_service.dart';
+
+void main() {
+  test('mobile export passes the complete JSON payload to the document picker',
+      () async {
+    Uint8List? savedBytes;
+    FileType? savedType;
+    List<String>? savedExtensions;
+    final service = VaultExportService(
+      pickerWritesBytes: true,
+      saveFile: ({
+        dialogTitle,
+        fileName,
+        type = FileType.any,
+        allowedExtensions,
+        bytes,
+      }) async {
+        savedBytes = bytes;
+        savedType = type;
+        savedExtensions = allowedExtensions;
+        return '/document/netcatty-mobile-export.json';
+      },
+    );
+    final vault = VaultData.fromJson({
+      'hosts': [
+        {
+          'id': 'host-1',
+          'label': 'NAS',
+          'hostname': '192.0.2.10',
+          'username': 'root',
+          'password': 'secret',
+        },
+      ],
+      'keys': [],
+      'snippets': [],
+      'customGroups': ['Home'],
+      'desktopPluginData': {'preserved': true},
+    });
+
+    final result = await service.export(vault);
+
+    expect(result, VaultExportResult.saved);
+    expect(savedType, FileType.custom);
+    expect(savedExtensions, ['json']);
+    expect(savedBytes, isNotNull);
+    final json = jsonDecode(utf8.decode(savedBytes!)) as Map<String, dynamic>;
+    expect((json['hosts'] as List).single['password'], 'secret');
+    expect(json['desktopPluginData'], {'preserved': true});
+  });
+
+  test('desktop export writes JSON to the selected filesystem path', () async {
+    final directory = await Directory.systemTemp.createTemp('vault-export-');
+    addTearDown(() => directory.delete(recursive: true));
+    final destination = File('${directory.path}/vault.json');
+    Uint8List? pickerBytes;
+    final service = VaultExportService(
+      pickerWritesBytes: false,
+      saveFile: ({
+        dialogTitle,
+        fileName,
+        type = FileType.any,
+        allowedExtensions,
+        bytes,
+      }) async {
+        pickerBytes = bytes;
+        return destination.path;
+      },
+    );
+
+    final result = await service.export(VaultData.empty());
+
+    expect(result, VaultExportResult.saved);
+    expect(pickerBytes, isNull);
+    expect(destination.existsSync(), isTrue);
+    expect(
+      jsonDecode(await destination.readAsString()),
+      containsPair('hosts', isEmpty),
+    );
+  });
+
+  test('cancelled export does not report success', () async {
+    final service = VaultExportService(
+      pickerWritesBytes: true,
+      saveFile: ({
+        dialogTitle,
+        fileName,
+        type = FileType.any,
+        allowedExtensions,
+        bytes,
+      }) async =>
+          null,
+    );
+
+    expect(
+      await service.export(VaultData.empty()),
+      VaultExportResult.cancelled,
+    );
+  });
+}


### PR DESCRIPTION
## 变更内容

- 在终端底部功能栏新增全屏按钮。
- 全屏时隐藏 SSH 标签栏和底部主导航，仅保留独立悬浮的性能监视按钮。
- Android 返回键会先退出终端全屏；会话不可见时也会自动退出，避免无法返回导航。
- iOS 目录选择改用原生 security-scoped URL，并保存安全书签以便应用重启后恢复挂载。
- iOS 在 `inactive` 阶段提前申请有限后台执行时间，恢复前台后继续使用自动重连兜底。
- 修复 Android/iOS 导出保险库 JSON 时没有把文件字节交给系统文档选择器的问题。

## 根因

- 原有 iOS 目录选择只保留了 URL 的字符串路径，没有调用 `startAccessingSecurityScopedResource()`，选择器关闭后应用没有权限枚举或修改目录。
- `file_picker` 在 Android/iOS 的 `saveFile()` 要求直接传入 `bytes`；旧实现把返回值当普通文件路径二次写入。
- ActivityKit Live Activity 不能访问网络，也不会赋予应用持续后台运行时间，因此不能用于维持 SSH socket。本改动保留 Apple 允许的有限后台宽限与前台恢复重连。

## 验证

- `flutter analyze --no-pub`
- `flutter test --no-pub`：36 项全部通过
- `flutter build apk --release --no-pub --dart-define=GITHUB_OAUTH_CLIENT_ID=Ov23lidR2u8OIkHW19nk`
- 本地 Release APK SHA-256：`1746acc2313949efd0d5ea8931fd18bbc498b4fb6a91f904f42f59502e4680dd`
- iOS Swift 编译与可重签 IPA 由本 PR 的 macOS CI 验证。
