### PR TITLE
feat: add SFTP transfer progress and optimize large transfers

### DIFF
--- a/lib/infrastructure/ssh/android_document_tree_service.dart
+++ b/lib/infrastructure/ssh/android_document_tree_service.dart
@@ -98,7 +98,10 @@ class AndroidDocumentTreeTransferService extends MountableFileTransferService {
   }
 
   @override
-  Stream<Uint8List> readStream(String path) async* {
+  Stream<Uint8List> readStream(
+    String path, {
+    TransferProgressCallback? onProgress,
+  }) async* {
     _requireMounted();
     final cachePath = await _channel.invokeMethod<String>(
       'copyToCache',
@@ -107,14 +110,21 @@ class AndroidDocumentTreeTransferService extends MountableFileTransferService {
     if (cachePath == null) throw StateError('无法读取手机文件');
     final cache = File(cachePath);
     try {
-      yield* cache.openRead().map(Uint8List.fromList);
+      final stream = asUint8ListStream(cache.openRead());
+      yield* onProgress == null
+          ? stream
+          : trackTransferProgress(stream, onProgress);
     } finally {
       if (await cache.exists()) await cache.delete();
     }
   }
 
   @override
-  Future<void> writeStream(String path, Stream<Uint8List> stream) async {
+  Future<void> writeStream(
+    String path,
+    Stream<Uint8List> stream, {
+    TransferProgressCallback? onProgress,
+  }) async {
     _requireMounted();
     final cacheDirectory = await getTemporaryDirectory();
     final cache = File(
@@ -124,7 +134,11 @@ class AndroidDocumentTreeTransferService extends MountableFileTransferService {
     try {
       final sink = cache.openWrite(mode: FileMode.writeOnly);
       try {
-        await sink.addStream(stream);
+        await sink.addStream(
+          onProgress == null
+              ? stream
+              : trackTransferProgress(stream, onProgress),
+        );
       } finally {
         await sink.close();
       }

--- a/lib/infrastructure/ssh/sftp_service.dart
+++ b/lib/infrastructure/ssh/sftp_service.dart
@@ -24,6 +24,8 @@ class RemoteEntry {
   final DateTime? modifiedAt;
 }
 
+typedef TransferProgressCallback = void Function(int transferredBytes);
+
 abstract class FileTransferService {
   String get id;
   String get displayName;
@@ -34,8 +36,15 @@ abstract class FileTransferService {
   String joinPath(String path, String name);
   String parentPath(String path);
   Future<List<RemoteEntry>> list(String path);
-  Stream<Uint8List> readStream(String path);
-  Future<void> writeStream(String path, Stream<Uint8List> stream);
+  Stream<Uint8List> readStream(
+    String path, {
+    TransferProgressCallback? onProgress,
+  });
+  Future<void> writeStream(
+    String path,
+    Stream<Uint8List> stream, {
+    TransferProgressCallback? onProgress,
+  });
   Future<void> mkdir(String path);
   Future<void> ensureDirectory(String path);
   Future<void> rename(String from, String to);
@@ -122,17 +131,26 @@ class SftpService extends FileTransferService {
   }
 
   @override
-  Stream<Uint8List> readStream(String path) async* {
+  Stream<Uint8List> readStream(
+    String path, {
+    TransferProgressCallback? onProgress,
+  }) async* {
     final file = await (await _sftp).open(path, mode: SftpFileOpenMode.read);
     try {
-      yield* file.read();
+      yield* Platform.isIOS
+          ? file.read(onProgress: onProgress, maxPendingRequests: 8)
+          : file.read(onProgress: onProgress);
     } finally {
       await file.close();
     }
   }
 
   @override
-  Future<void> writeStream(String path, Stream<Uint8List> stream) async {
+  Future<void> writeStream(
+    String path,
+    Stream<Uint8List> stream, {
+    TransferProgressCallback? onProgress,
+  }) async {
     final file = await (await _sftp).open(
       path,
       mode: SftpFileOpenMode.create |
@@ -140,7 +158,15 @@ class SftpService extends FileTransferService {
           SftpFileOpenMode.truncate,
     );
     try {
-      await file.write(stream).done;
+      if (Platform.isIOS) {
+        await _writeSftpStreamWithLimitedConcurrency(
+          file,
+          stream,
+          onProgress: onProgress,
+        );
+      } else {
+        await file.write(stream, onProgress: onProgress).done;
+      }
     } finally {
       await file.close();
     }
@@ -164,7 +190,7 @@ class SftpService extends FileTransferService {
       (await _sftp).rename(from, to);
 
   /// Retained for callers that copy within this SSH session.
-  Future<void> copyEntry(RemoteEntry entry, String targetDirectory) =>
+  Future<int> copyEntry(RemoteEntry entry, String targetDirectory) =>
       transferEntry(this, entry, this, targetDirectory);
 
   @override
@@ -288,16 +314,29 @@ class LocalFileTransferService extends MountableFileTransferService {
   }
 
   @override
-  Stream<Uint8List> readStream(String path) =>
-      File(path).openRead().map((chunk) => Uint8List.fromList(chunk));
+  Stream<Uint8List> readStream(
+    String path, {
+    TransferProgressCallback? onProgress,
+  }) {
+    final stream = asUint8ListStream(File(path).openRead());
+    return onProgress == null
+        ? stream
+        : trackTransferProgress(stream, onProgress);
+  }
 
   @override
-  Future<void> writeStream(String path, Stream<Uint8List> stream) async {
+  Future<void> writeStream(
+    String path,
+    Stream<Uint8List> stream, {
+    TransferProgressCallback? onProgress,
+  }) async {
     final file = File(path);
     await file.parent.create(recursive: true);
     final sink = file.openWrite(mode: FileMode.writeOnly);
     try {
-      await sink.addStream(stream);
+      await sink.addStream(
+        onProgress == null ? stream : trackTransferProgress(stream, onProgress),
+      );
     } finally {
       await sink.close();
     }
@@ -326,12 +365,25 @@ class LocalFileTransferService extends MountableFileTransferService {
       : File(entry.path).delete();
 }
 
-Future<void> transferEntry(
+Future<int> calculateTransferSize(
+  FileTransferService source,
+  RemoteEntry entry,
+) async {
+  if (!entry.isDirectory) return entry.size;
+  var total = 0;
+  for (final child in await source.list(entry.path)) {
+    total += await calculateTransferSize(source, child);
+  }
+  return total;
+}
+
+Future<int> transferEntry(
   FileTransferService source,
   RemoteEntry entry,
   FileTransferService target,
-  String targetDirectory,
-) async {
+  String targetDirectory, {
+  TransferProgressCallback? onProgress,
+}) async {
   final targetPath = target.joinPath(targetDirectory, entry.name);
   final separator = source.isLocal ? Platform.pathSeparator : '/';
   if (source.id == target.id &&
@@ -339,14 +391,96 @@ Future<void> transferEntry(
           targetPath.startsWith('${entry.path}$separator'))) {
     throw StateError('不能把文件或目录复制到自身');
   }
-  if (entry.isDirectory) {
-    await target.ensureDirectory(targetPath);
-    for (final child in await source.list(entry.path)) {
-      await transferEntry(source, child, target, targetPath);
+
+  var transferred = 0;
+
+  Future<void> copy(RemoteEntry current, String directory) async {
+    final currentTargetPath = target.joinPath(directory, current.name);
+    if (current.isDirectory) {
+      await target.ensureDirectory(currentTargetPath);
+      for (final child in await source.list(current.path)) {
+        await copy(child, currentTargetPath);
+      }
+      return;
     }
-    return;
+
+    final baseline = transferred;
+    var fileProgress = 0;
+    await target.writeStream(
+      currentTargetPath,
+      source.readStream(current.path),
+      onProgress: (value) {
+        fileProgress = value;
+        onProgress?.call(baseline + value);
+      },
+    );
+    transferred = baseline + fileProgress;
   }
-  await target.writeStream(targetPath, source.readStream(entry.path));
+
+  await copy(entry, targetDirectory);
+  return transferred;
+}
+
+Stream<Uint8List> asUint8ListStream(Stream<List<int>> source) => source.map(
+      (chunk) => chunk is Uint8List ? chunk : Uint8List.fromList(chunk),
+    );
+
+Stream<Uint8List> trackTransferProgress(
+  Stream<Uint8List> source,
+  TransferProgressCallback onProgress,
+) async* {
+  var transferred = 0;
+  await for (final chunk in source) {
+    yield chunk;
+    transferred += chunk.length;
+    onProgress(transferred);
+  }
+}
+
+Future<void> _writeSftpStreamWithLimitedConcurrency(
+  SftpFile file,
+  Stream<Uint8List> stream, {
+  TransferProgressCallback? onProgress,
+  int maxPendingWrites = 8,
+}) async {
+  const maxChunkSize = 16 * 1024;
+  var offset = 0;
+  var acknowledged = 0;
+  var batch = <Future<int>>[];
+
+  Future<void> flushBatch() async {
+    if (batch.isEmpty) return;
+    final completed = await Future.wait(batch);
+    acknowledged += completed.fold(0, (total, value) => total + value);
+    onProgress?.call(acknowledged);
+    batch = <Future<int>>[];
+  }
+
+  await for (final chunk in _splitByteChunks(stream, maxChunkSize)) {
+    final writeOffset = offset;
+    offset += chunk.length;
+    batch.add(
+      file.writeBytes(chunk, offset: writeOffset).then((_) => chunk.length),
+    );
+    if (batch.length >= maxPendingWrites) await flushBatch();
+  }
+  await flushBatch();
+}
+
+Stream<Uint8List> _splitByteChunks(
+  Stream<Uint8List> source,
+  int maxChunkSize,
+) async* {
+  await for (final chunk in source) {
+    if (chunk.length <= maxChunkSize) {
+      yield chunk;
+      continue;
+    }
+    for (var offset = 0; offset < chunk.length; offset += maxChunkSize) {
+      final end = (offset + maxChunkSize).clamp(0, chunk.length);
+      yield Uint8List.sublistView(chunk, offset, end);
+    }
+  }
 }
 
 String joinRemotePath(String path, String name) =>

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -25,7 +25,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   var _rightKey = GlobalKey<_SftpPaneState>();
   String? _leftSourceId;
   String? _rightSourceId = 'local';
-  var _copying = false;
+  _TransferProgressSnapshot? _transfer;
 
   @override
   void initState() {
@@ -76,37 +76,34 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
             children: [
               Material(
                 color: Theme.of(context).colorScheme.surface,
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(12, 7, 12, 7),
-                  child: Row(
-                    children: [
-                      Icon(
-                        Icons.compare_arrows,
-                        color: Theme.of(context).colorScheme.primary,
+                child: Column(
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.fromLTRB(12, 7, 12, 7),
+                      child: Row(
+                        children: [
+                          Icon(
+                            Icons.compare_arrows,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                          const SizedBox(width: 8),
+                          const Expanded(
+                            child: Text(
+                              '双栏文件传输',
+                              style: TextStyle(fontWeight: FontWeight.w600),
+                            ),
+                          ),
+                          if (sessions.isEmpty)
+                            const Text(
+                              '连接 SSH 后可选择服务器',
+                              style: TextStyle(fontSize: 11),
+                            ),
+                        ],
                       ),
-                      const SizedBox(width: 8),
-                      const Expanded(
-                        child: Text(
-                          '双栏文件传输',
-                          style: TextStyle(fontWeight: FontWeight.w600),
-                        ),
-                      ),
-                      if (sessions.isEmpty)
-                        const Text(
-                          '连接 SSH 后可选择服务器',
-                          style: TextStyle(fontSize: 11),
-                        ),
-                      if (_copying) ...[
-                        const SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(strokeWidth: 2),
-                        ),
-                        const SizedBox(width: 6),
-                        const Text('传输中', style: TextStyle(fontSize: 12)),
-                      ],
-                    ],
-                  ),
+                    ),
+                    if (_transfer != null)
+                      _TransferProgressView(progress: _transfer!),
+                  ],
                 ),
               ),
               Expanded(
@@ -178,15 +175,29 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
   ) async {
     final source = sourceKey.currentState;
     final target = targetKey.currentState;
-    if (source == null || target == null || _copying) return;
-    setState(() => _copying = true);
+    if (source == null || target == null || _transfer != null) return;
+    final tracker = _TransferProgressTracker(
+      title: '${entry.name} → ${target.service.displayName}',
+      totalBytes: entry.isDirectory ? null : entry.size,
+      onChanged: (progress) {
+        if (mounted) setState(() => _transfer = progress);
+      },
+    )..start(preparing: entry.isDirectory);
     try {
+      if (entry.isDirectory) {
+        tracker.setTotalBytes(await calculateTransferSize(
+          source.service,
+          entry,
+        ));
+      }
       await transferEntry(
         source.service,
         entry,
         target.service,
         target.path,
+        onProgress: tracker.update,
       );
+      tracker.finish();
       await target.refresh();
       _message(
         '已将 ${entry.name} 从 ${source.service.displayName} 传输到'
@@ -195,7 +206,7 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     } catch (error) {
       _message('传输失败：$error');
     } finally {
-      if (mounted) setState(() => _copying = false);
+      if (mounted) setState(() => _transfer = null);
     }
   }
 
@@ -234,6 +245,7 @@ class _SftpPaneState extends State<_SftpPane> {
   var _loading = false;
   Object? _error;
   List<RemoteEntry> _entries = const [];
+  _TransferProgressSnapshot? _transfer;
 
   FileTransferService get service => widget.service;
 
@@ -354,27 +366,50 @@ class _SftpPaneState extends State<_SftpPane> {
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   children: [
-                    _toolbar(Icons.arrow_upward, '上级',
-                        !localReady || path == service.rootPath ? null : _up),
-                    _toolbar(Icons.refresh, '刷新',
-                        _loading || !localReady ? null : refresh),
-                    if (mountable != null && !mountable.usesAppDocuments)
-                      _toolbar(
-                        Icons.folder_open_outlined,
-                        mountable.isMounted ? '更换挂载目录' : '挂载手机目录',
-                        _mountPhoneDirectory,
+                    Expanded(
+                      child: _toolbar(
+                        Icons.arrow_upward,
+                        '上级',
+                        !localReady || path == service.rootPath ? null : _up,
                       ),
-                    _toolbar(
-                      service.isLocal ? Icons.add_to_photos : Icons.upload_file,
-                      service.isLocal ? '导入其他手机文件' : '上传文件',
-                      localReady ? _importFile : null,
                     ),
-                    _toolbar(Icons.create_new_folder_outlined, '新建',
-                        localReady ? _mkdir : null),
+                    Expanded(
+                      child: _toolbar(
+                        Icons.refresh,
+                        '刷新',
+                        _loading || !localReady ? null : refresh,
+                      ),
+                    ),
+                    if (mountable != null && !mountable.usesAppDocuments)
+                      Expanded(
+                        child: _toolbar(
+                          Icons.folder_open_outlined,
+                          mountable.isMounted ? '更换挂载目录' : '挂载手机目录',
+                          _mountPhoneDirectory,
+                        ),
+                      ),
+                    Expanded(
+                      child: _toolbar(
+                        service.isLocal
+                            ? Icons.add_to_photos
+                            : Icons.upload_file,
+                        service.isLocal ? '导入其他手机文件' : '上传文件',
+                        localReady && _transfer == null ? _importFile : null,
+                      ),
+                    ),
+                    Expanded(
+                      child: _toolbar(
+                        Icons.create_new_folder_outlined,
+                        '新建',
+                        localReady ? _mkdir : null,
+                      ),
+                    ),
                   ],
                 ),
               ),
               if (_loading) const LinearProgressIndicator(minHeight: 2),
+              if (_transfer != null)
+                _TransferProgressView(progress: _transfer!, compact: true),
               if (_error != null)
                 InkWell(
                   onTap: refresh,
@@ -482,6 +517,8 @@ class _SftpPaneState extends State<_SftpPane> {
       IconButton(
         tooltip: tooltip,
         onPressed: onPressed,
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(minWidth: 32, minHeight: 32),
         visualDensity: VisualDensity.compact,
         iconSize: 20,
         icon: Icon(icon),
@@ -583,28 +620,41 @@ class _SftpPaneState extends State<_SftpPane> {
   }
 
   Future<void> _importFile() async {
+    if (_transfer != null) return;
     final result = await FilePicker.platform.pickFiles(withReadStream: true);
     if (result == null) return;
     final file = result.files.single;
     Stream<Uint8List>? stream;
     if (file.readStream != null) {
-      stream = file.readStream!.map(Uint8List.fromList);
+      stream = asUint8ListStream(file.readStream!);
     } else if (file.path != null) {
-      stream = File(file.path!).openRead().map(Uint8List.fromList);
+      stream = asUint8ListStream(File(file.path!).openRead());
     } else if (file.bytes != null) {
       stream = Stream.value(file.bytes!);
     }
     if (stream == null) return;
+    final tracker = _beginTransfer(
+      '${service.isLocal ? '导入' : '上传'} ${file.name}',
+      file.size,
+    );
     try {
-      await service.writeStream(service.joinPath(path, file.name), stream);
+      await service.writeStream(
+        service.joinPath(path, file.name),
+        stream,
+        onProgress: tracker.update,
+      );
+      tracker.finish();
       await refresh();
       _message(service.isLocal ? '已导入到挂载目录' : '上传完成');
     } catch (error) {
       _message('$error');
+    } finally {
+      _endTransfer();
     }
   }
 
   Future<void> _share(RemoteEntry entry) async {
+    if (_transfer != null) return;
     try {
       late final File file;
       if (service is LocalFileTransferService) {
@@ -615,10 +665,15 @@ class _SftpPaneState extends State<_SftpPane> {
           '${directory.path}/${DateTime.now().millisecondsSinceEpoch}-${entry.name}',
         );
         final sink = file.openWrite(mode: FileMode.writeOnly);
+        final tracker = _beginTransfer('下载 ${entry.name}', entry.size);
         try {
-          await sink.addStream(service.readStream(entry.path));
+          await sink.addStream(
+            service.readStream(entry.path, onProgress: tracker.update),
+          );
+          tracker.finish();
         } finally {
           await sink.close();
+          _endTransfer();
         }
       }
       await SharePlus.instance.share(
@@ -711,6 +766,192 @@ class _SftpPaneState extends State<_SftpPane> {
           .showSnackBar(SnackBar(content: Text(value)));
     }
   }
+
+  _TransferProgressTracker _beginTransfer(String title, int totalBytes) {
+    final tracker = _TransferProgressTracker(
+      title: title,
+      totalBytes: totalBytes,
+      onChanged: (progress) {
+        if (mounted) setState(() => _transfer = progress);
+      },
+    )..start();
+    return tracker;
+  }
+
+  void _endTransfer() {
+    if (mounted) setState(() => _transfer = null);
+  }
+}
+
+class _TransferProgressSnapshot {
+  const _TransferProgressSnapshot({
+    required this.title,
+    required this.transferredBytes,
+    required this.totalBytes,
+    required this.bytesPerSecond,
+    required this.preparing,
+  });
+
+  final String title;
+  final int transferredBytes;
+  final int? totalBytes;
+  final double bytesPerSecond;
+  final bool preparing;
+
+  double? get value {
+    final total = totalBytes;
+    if (preparing || total == null || total <= 0) return null;
+    return (transferredBytes / total).clamp(0.0, 1.0).toDouble();
+  }
+}
+
+class _TransferProgressTracker {
+  _TransferProgressTracker({
+    required this.title,
+    required int? totalBytes,
+    required ValueChanged<_TransferProgressSnapshot> onChanged,
+  })  : _totalBytes = totalBytes,
+        _onChanged = onChanged;
+
+  static const _minimumUpdateInterval = Duration(milliseconds: 200);
+  static const _minimumByteDelta = 256 * 1024;
+
+  final String title;
+  final ValueChanged<_TransferProgressSnapshot> _onChanged;
+  final Stopwatch _watch = Stopwatch();
+  int? _totalBytes;
+  int _transferredBytes = 0;
+  int _lastEmittedBytes = 0;
+  Duration _lastEmittedAt = Duration.zero;
+  double _bytesPerSecond = 0;
+  bool _preparing = false;
+
+  void start({bool preparing = false}) {
+    _preparing = preparing;
+    _watch.start();
+    _emit(0, force: true);
+  }
+
+  void setTotalBytes(int value) {
+    _totalBytes = value;
+    _preparing = false;
+    _emit(_transferredBytes, force: true);
+  }
+
+  void update(int value) {
+    _preparing = false;
+    _emit(value);
+  }
+
+  void finish() {
+    _emit(_totalBytes ?? _transferredBytes, force: true);
+  }
+
+  void _emit(int value, {bool force = false}) {
+    final now = _watch.elapsed;
+    final elapsedSinceUpdate = now - _lastEmittedAt;
+    final byteDelta = value - _lastEmittedBytes;
+    final complete = _totalBytes != null && value >= _totalBytes!;
+    if (!force &&
+        !complete &&
+        elapsedSinceUpdate < _minimumUpdateInterval &&
+        byteDelta < _minimumByteDelta) {
+      return;
+    }
+
+    final micros = elapsedSinceUpdate.inMicroseconds;
+    if (micros > 0 && byteDelta >= 0) {
+      final instantSpeed = byteDelta * Duration.microsecondsPerSecond / micros;
+      _bytesPerSecond = _bytesPerSecond == 0
+          ? instantSpeed
+          : (_bytesPerSecond * .7) + (instantSpeed * .3);
+    }
+    _transferredBytes = value;
+    _lastEmittedBytes = value;
+    _lastEmittedAt = now;
+    _onChanged(
+      _TransferProgressSnapshot(
+        title: title,
+        transferredBytes: value,
+        totalBytes: _totalBytes,
+        bytesPerSecond: _bytesPerSecond,
+        preparing: _preparing,
+      ),
+    );
+  }
+}
+
+class _TransferProgressView extends StatelessWidget {
+  const _TransferProgressView({
+    required this.progress,
+    this.compact = false,
+  });
+
+  final _TransferProgressSnapshot progress;
+  final bool compact;
+
+  @override
+  Widget build(BuildContext context) {
+    final total = progress.totalBytes;
+    final percent = progress.value == null
+        ? null
+        : '${(progress.value! * 100).toStringAsFixed(0)}%';
+    final speed = progress.bytesPerSecond <= 0
+        ? null
+        : '${_formatBytes(progress.bytesPerSecond.round())}/s';
+    final details = progress.preparing
+        ? '正在计算文件大小…'
+        : [
+            if (percent != null) percent,
+            total == null || total <= 0
+                ? _formatBytes(progress.transferredBytes)
+                : '${_formatBytes(progress.transferredBytes)} / ${_formatBytes(total)}',
+            if (speed != null) speed,
+          ].join(' · ');
+    return Semantics(
+      label: '${progress.title} $details',
+      child: Padding(
+        padding: EdgeInsets.fromLTRB(8, compact ? 2 : 0, 8, 6),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  flex: 2,
+                  child: Text(
+                    progress.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: TextStyle(
+                      fontSize: compact ? 10 : 11,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 6),
+                Expanded(
+                  flex: 3,
+                  child: Text(
+                    details,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.end,
+                    style: TextStyle(fontSize: compact ? 9 : 10),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            LinearProgressIndicator(
+              value: progress.value,
+              minHeight: compact ? 3 : 4,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 }
 
 IconData _fileIcon(String name) =>
@@ -727,4 +968,6 @@ String _formatBytes(int value) => value < 1024
     ? '$value B'
     : value < 1024 * 1024
         ? '${(value / 1024).toStringAsFixed(1)} KB'
-        : '${(value / 1024 / 1024).toStringAsFixed(1)} MB';
+        : value < 1024 * 1024 * 1024
+            ? '${(value / 1024 / 1024).toStringAsFixed(1)} MB'
+            : '${(value / 1024 / 1024 / 1024).toStringAsFixed(1)} GB';

--- a/test/sftp_terminal_usability_test.dart
+++ b/test/sftp_terminal_usability_test.dart
@@ -88,10 +88,31 @@ void main() {
       size: 0,
     );
 
-    await transferEntry(source, entry, target, '/incoming');
+    final progress = <int>[];
+    expect(await calculateTransferSize(source, entry), 4);
+    final transferred = await transferEntry(
+      source,
+      entry,
+      target,
+      '/incoming',
+      onProgress: progress.add,
+    );
 
     expect(target.directories, contains('/incoming/logs'));
     expect(target.files['/incoming/logs/app.log'], [1, 2, 3, 4]);
+    expect(transferred, 4);
+    expect(progress, isNotEmpty);
+    expect(progress.last, 4);
+  });
+
+  test('typed file chunks are reused without an extra memory copy', () async {
+    final chunk = Uint8List.fromList([1, 2, 3]);
+
+    final normalized = await asUint8ListStream(
+      Stream<List<int>>.value(chunk),
+    ).single;
+
+    expect(identical(normalized, chunk), isTrue);
   });
 
   testWidgets('quick key region wraps without horizontal scrolling',
@@ -258,13 +279,26 @@ class _MemoryTransferService extends FileTransferService {
   }
 
   @override
-  Stream<Uint8List> readStream(String path) => Stream.value(files[path]!);
+  Stream<Uint8List> readStream(
+    String path, {
+    TransferProgressCallback? onProgress,
+  }) {
+    final stream = Stream.value(files[path]!);
+    return onProgress == null
+        ? stream
+        : trackTransferProgress(stream, onProgress);
+  }
 
   @override
-  Future<void> writeStream(String path, Stream<Uint8List> stream) async {
+  Future<void> writeStream(
+    String path,
+    Stream<Uint8List> stream, {
+    TransferProgressCallback? onProgress,
+  }) async {
     final builder = BytesBuilder(copy: false);
     await for (final chunk in stream) {
       builder.add(chunk);
+      onProgress?.call(builder.length);
     }
     files[path] = builder.takeBytes();
   }


### PR DESCRIPTION
## What changed

- Show transfer percentage, transferred/total bytes, and live speed for SFTP uploads, downloads, directory copies, and cross-server transfers.
- Calculate total directory size before recursive transfers so directory progress is determinate.
- Reduce iOS SFTP read/write concurrency and use bounded streaming batches for large files.
- Avoid unnecessary `Uint8List` copies and throttle progress UI updates to reduce allocation and rebuild pressure.
- Make Android dual-pane SFTP toolbar buttons share the available width so icons no longer cross the center divider on narrow screens.
- Extend transfer service tests for recursive byte totals, progress callbacks, and zero-copy typed chunks.

## Why

Large SFTP transfers on iOS could make the app visibly stutter. The SSH encryption work, many small pending SFTP operations, repeated byte-buffer copies, and frequent UI updates all competed on Flutter's UI isolate. The bounded iOS pipeline and throttled progress updates reduce that pressure while keeping transfers streamed instead of loading whole files into memory.

Android's dual-pane toolbar also inherited the default 48dp minimum width of each `IconButton`. Five actions could exceed one pane's width, so the last icon rendered over the center divider. Each action now receives an equal share of the pane width with compact constraints.

## Validation

- `flutter analyze` — passed
- `flutter test --no-pub test/sftp_terminal_usability_test.dart` — 9/9 passed
- Full Flutter test suite — 38/38 passed during the transfer implementation
- Android Debug APK build — passed during the transfer implementation
