### PR TITLE
Add in-app release update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Netcatty 的 Android / iOS 移动端实现：一个面向服务器管理、SSH �
 - **与桌面端兼容的保险库**：支持 WebDAV 和 GitHub OAuth/Gist 云同步；未知字段无损保留，方便桌面端与移动端交替使用。
 - **安全优先**：密码、私钥、同步主密码和 API Key 分别保存到 Android Keystore / iOS Keychain；云端保险库采用 PBKDF2-SHA256 与 AES-256-GCM 加密。
 - **高度可定制**：网格、列表、树形三种主机视图，浅色/深色主题库，命令片段以及可排序的终端快捷键。
+- **内置更新检查**：设置页自动比较当前应用版本与 GitHub 最新正式 Release，发现新版本后可直接前往下载页面。
 
 ## 特色功能预览
 
@@ -130,6 +131,7 @@ Netcatty 的 Android / iOS 移动端实现：一个面向服务器管理、SSH �
 - 本地普通偏好设置不保存密码、私钥、同步密码、Token 或 API Key
 - Android 禁用明文网络和系统备份；iOS 凭据使用设备 Keychain
 - Catty Agent 只生成建议命令，执行前必须由用户确认
+- 设置页自动检查 GitHub 最新 Release，并显示当前是否为最新版本
 
 ## 平台差异
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -161,6 +161,17 @@ Docker 调用会探测直接访问、免密 sudo 和需要密码的 sudo。破�
 
 合并策略以记录的更新时间为主，同时保留远端未知字段。不要把“同步成功”等同于简单覆盖上传。
 
+## 更新检查
+
+`UpdateCheckService` 调用 GitHub REST API 的 `releases/latest` 端点，读取最新正式 Release 的 `tag_name` 和 `html_url`。设置页使用 `package_info_plus` 获取当前应用版本，忽略 Tag 的 `v` 前缀和 Build Metadata 后进行语义版本比较：
+
+- 版本相同：显示“已是最新版本”。
+- GitHub 版本更高：显示可用更新和最新版本号。
+- 当前版本更高：标记为开发版本，不错误提示降级更新。
+- 网络或响应异常：显示可重试错误，不影响设置页其他功能。
+
+成功状态的卡片始终可跳转到对应 GitHub Release；返回 URL 只接受 `https://github.com`，否则回退到仓库固定的 `/releases/latest` 页面。检查请求不携带 GitHub Token，也不应因为版本检查失败阻塞应用启动。
+
 ## 主题与资源
 
 `presentation/theme.dart` 保存桌面端迁移的主题预设；发行版和 Docker 图标分别位于 `assets/distro` 与 `assets/docker`。主题颜色会同时影响应用组件、终端和 iOS PiP 文本帧。

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -98,6 +98,7 @@ Windows 无法完成原生 iOS 编译；涉及 Swift、Info.plist 或 iOS Plugin
 | `vault_model_test.dart` | Vault 字段、未知字段无损往返和模型迁移 |
 | `netcatty_crypto_test.dart` | 桌面端兼容加密向量与 AES-GCM 格式 |
 | `github_auth_service_test.dart` | Device Flow、轮询、重试、取消与网络错误 |
+| `update_check_service_test.dart` | GitHub Latest Release 解析、语义版本比较与网络错误 |
 | `vault_export_service_test.dart` | JSON 导出与取消路径 |
 | `host_editor_layout_test.dart` | 键盘弹出、滚动和窄屏表单布局 |
 | `terminal_connection_dialog_test.dart` | Pending 标签、连接弹窗和会话隔离 |

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -86,6 +86,7 @@ Netcatty-mobile/
 | `sync/netcatty_crypto.dart` | 桌面兼容 PBKDF2 + AES-GCM 加密格式 |
 | `sync/cloud_sync_service.dart` | WebDAV/Gist 下载、解密、合并、加密上传与 Gist 发现 |
 | `sync/github_auth_service.dart` | GitHub OAuth Device Flow、轮询、网络重试和用户信息读取 |
+| `update_check_service.dart` | GitHub Latest Release 查询、版本比较和安全下载链接 |
 
 ### AI
 
@@ -176,6 +177,7 @@ assets/
 - 模型与 Vault 无损往返
 - 桌面端加密兼容
 - GitHub Device Flow
+- GitHub Release 更新检查与版本比较
 - 主机编辑器和终端连接 UI
 - SFTP/快捷键/PiP 可用性
 - 系统管理命令与解析

--- a/lib/infrastructure/update_check_service.dart
+++ b/lib/infrastructure/update_check_service.dart
@@ -1,0 +1,192 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
+class UpdateCheckException implements Exception {
+  const UpdateCheckException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}
+
+class UpdateCheckResult {
+  const UpdateCheckResult({
+    required this.currentVersion,
+    required this.latestVersion,
+    required this.releaseUri,
+  });
+
+  final String currentVersion;
+  final String latestVersion;
+  final Uri releaseUri;
+
+  bool get isLatest =>
+      compareReleaseVersions(currentVersion, latestVersion) == 0;
+
+  bool get updateAvailable =>
+      compareReleaseVersions(latestVersion, currentVersion) > 0;
+
+  bool get isDevelopmentVersion =>
+      compareReleaseVersions(currentVersion, latestVersion) > 0;
+}
+
+class UpdateCheckService {
+  UpdateCheckService({
+    http.Client? client,
+    this.requestTimeout = const Duration(seconds: 15),
+  })  : _client = client ?? http.Client(),
+        _ownsClient = client == null;
+
+  static final latestReleaseApi = Uri.parse(
+    'https://api.github.com/repos/kmh1145/Netcatty-mobile/releases/latest',
+  );
+  static final latestReleasePage = Uri.parse(
+    'https://github.com/kmh1145/Netcatty-mobile/releases/latest',
+  );
+
+  final http.Client _client;
+  final bool _ownsClient;
+  final Duration requestTimeout;
+
+  Future<UpdateCheckResult> check(String currentVersion) async {
+    late final http.Response response;
+    try {
+      response = await _client.get(
+        latestReleaseApi,
+        headers: const {
+          'accept': 'application/vnd.github+json',
+          'x-github-api-version': '2022-11-28',
+          'user-agent': 'Netcatty-Mobile',
+        },
+      ).timeout(requestTimeout);
+    } on TimeoutException {
+      throw const UpdateCheckException('检查更新超时，请稍后重试');
+    } on http.ClientException {
+      throw const UpdateCheckException('无法连接 GitHub，请检查网络后重试');
+    }
+
+    if (response.statusCode < 200 || response.statusCode >= 300) {
+      throw UpdateCheckException(
+        '检查更新失败（HTTP ${response.statusCode}）',
+      );
+    }
+
+    final Object? decoded;
+    try {
+      decoded = jsonDecode(response.body);
+    } on FormatException {
+      throw const UpdateCheckException('GitHub 返回了无法识别的版本信息');
+    }
+    if (decoded is! Map) {
+      throw const UpdateCheckException('GitHub 返回了无法识别的版本信息');
+    }
+
+    final tagName = decoded['tag_name']?.toString().trim() ?? '';
+    if (tagName.isEmpty) {
+      throw const UpdateCheckException('最新 Release 缺少版本号');
+    }
+    final latestVersion = tagName.replaceFirst(RegExp(r'^[vV]'), '');
+    try {
+      compareReleaseVersions(currentVersion, latestVersion);
+    } on FormatException {
+      throw const UpdateCheckException('最新 Release 版本号格式无效');
+    }
+
+    final candidate = Uri.tryParse(decoded['html_url']?.toString() ?? '');
+    final releaseUri = candidate != null &&
+            candidate.scheme == 'https' &&
+            candidate.host == 'github.com'
+        ? candidate
+        : latestReleasePage;
+    return UpdateCheckResult(
+      currentVersion: currentVersion,
+      latestVersion: latestVersion,
+      releaseUri: releaseUri,
+    );
+  }
+
+  void close() {
+    if (_ownsClient) _client.close();
+  }
+}
+
+int compareReleaseVersions(String left, String right) {
+  final leftVersion = _ReleaseVersion.parse(left);
+  final rightVersion = _ReleaseVersion.parse(right);
+  for (var index = 0; index < 3; index++) {
+    final compared = leftVersion.numbers[index].compareTo(
+      rightVersion.numbers[index],
+    );
+    if (compared != 0) return compared;
+  }
+
+  final leftPre = leftVersion.preRelease;
+  final rightPre = rightVersion.preRelease;
+  if (leftPre == null && rightPre == null) return 0;
+  if (leftPre == null) return 1;
+  if (rightPre == null) return -1;
+  final length =
+      leftPre.length > rightPre.length ? leftPre.length : rightPre.length;
+  for (var index = 0; index < length; index++) {
+    if (index >= leftPre.length) return -1;
+    if (index >= rightPre.length) return 1;
+    final leftPart = leftPre[index];
+    final rightPart = rightPre[index];
+    final leftNumber = int.tryParse(leftPart);
+    final rightNumber = int.tryParse(rightPart);
+    if (leftNumber != null && rightNumber != null) {
+      final compared = leftNumber.compareTo(rightNumber);
+      if (compared != 0) return compared;
+    } else if (leftNumber != null) {
+      return -1;
+    } else if (rightNumber != null) {
+      return 1;
+    } else {
+      final compared = leftPart.compareTo(rightPart);
+      if (compared != 0) return compared;
+    }
+  }
+  return 0;
+}
+
+class _ReleaseVersion {
+  const _ReleaseVersion(this.numbers, this.preRelease);
+
+  final List<int> numbers;
+  final List<String>? preRelease;
+
+  factory _ReleaseVersion.parse(String value) {
+    final withoutPrefix = value.trim().replaceFirst(RegExp(r'^[vV]'), '');
+    final withoutBuild = withoutPrefix.split('+').first;
+    final dash = withoutBuild.indexOf('-');
+    final core = dash < 0 ? withoutBuild : withoutBuild.substring(0, dash);
+    final rawPre = dash < 0 ? null : withoutBuild.substring(dash + 1);
+    final parts = core.split('.');
+    if (parts.isEmpty || parts.length > 3) {
+      throw FormatException('Invalid release version: $value');
+    }
+    final numbers = <int>[];
+    for (final part in parts) {
+      final parsed = int.tryParse(part);
+      if (parsed == null || parsed < 0) {
+        throw FormatException('Invalid release version: $value');
+      }
+      numbers.add(parsed);
+    }
+    while (numbers.length < 3) {
+      numbers.add(0);
+    }
+    final preRelease = rawPre
+        ?.split('.')
+        .where((part) => part.isNotEmpty)
+        .map((part) => part.toLowerCase())
+        .toList(growable: false);
+    if (preRelease?.isEmpty ?? false) {
+      throw FormatException('Invalid release version: $value');
+    }
+    return _ReleaseVersion(numbers, preRelease);
+  }
+}

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -17,6 +17,7 @@ import '../../infrastructure/storage/vault_repository.dart';
 import '../../infrastructure/storage/vault_export_service.dart';
 import '../../infrastructure/sync/cloud_sync_service.dart';
 import '../../infrastructure/sync/github_auth_service.dart';
+import '../../infrastructure/update_check_service.dart';
 import '../theme.dart';
 import '../widgets/keychain_sheet.dart';
 
@@ -28,7 +29,9 @@ class SettingsScreen extends ConsumerStatefulWidget {
 }
 
 class _SettingsScreenState extends ConsumerState<SettingsScreen> {
-  late final Future<PackageInfo> _packageInfo = PackageInfo.fromPlatform();
+  late final Future<PackageInfo> _packageInfo;
+  late final UpdateCheckService _updateCheckService;
+  late Future<UpdateCheckResult> _updateCheck;
   final endpoint = TextEditingController();
   final username = TextEditingController();
   final providerSecret = TextEditingController();
@@ -46,12 +49,34 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   String? _githubUser;
 
   @override
+  void initState() {
+    super.initState();
+    _packageInfo = PackageInfo.fromPlatform();
+    _updateCheckService = UpdateCheckService();
+    _updateCheck = _checkForUpdates();
+  }
+
+  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!_loaded) {
       _loaded = true;
       _load();
     }
+  }
+
+  @override
+  void dispose() {
+    _updateCheckService.close();
+    endpoint.dispose();
+    username.dispose();
+    providerSecret.dispose();
+    resourceId.dispose();
+    masterPassword.dispose();
+    aiEndpoint.dispose();
+    aiModel.dispose();
+    aiKey.dispose();
+    super.dispose();
   }
 
   Future<void> _load() async {
@@ -391,6 +416,8 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                   ],
                 ),
               ),
+              _header('关于与更新', '自动检查 GitHub 上的最新正式版本'),
+              Card(child: _updateCheckTile()),
               const SizedBox(height: 20),
               Center(
                 child: FutureBuilder<PackageInfo>(
@@ -424,6 +451,82 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ],
         ),
       );
+
+  Widget _updateCheckTile() => FutureBuilder<UpdateCheckResult>(
+        future: _updateCheck,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const ListTile(
+              leading: SizedBox.square(
+                dimension: 24,
+                child: CircularProgressIndicator(strokeWidth: 2.5),
+              ),
+              title: Text('正在检查更新'),
+              subtitle: Text('正在查询 GitHub 最新 Release'),
+            );
+          }
+          if (snapshot.hasError) {
+            return ListTile(
+              leading: Icon(
+                Icons.error_outline,
+                color: Theme.of(context).colorScheme.error,
+              ),
+              title: const Text('检查更新失败'),
+              subtitle: Text('${snapshot.error}\n点按重试'),
+              isThreeLine: true,
+              trailing: const Icon(Icons.refresh),
+              onTap: _retryUpdateCheck,
+            );
+          }
+
+          final result = snapshot.requireData;
+          final title = result.updateAvailable
+              ? '发现新版本 ${result.latestVersion}'
+              : result.isLatest
+                  ? '已是最新版本'
+                  : '当前为开发版本';
+          final subtitle = result.updateAvailable
+              ? '当前版本 ${result.currentVersion} · 点按前往下载'
+              : result.isLatest
+                  ? '当前版本 ${result.currentVersion} · 点按查看最新 Release'
+                  : '当前 ${result.currentVersion} · 最新正式版 ${result.latestVersion}';
+          final icon = result.updateAvailable
+              ? Icons.system_update_alt
+              : result.isLatest
+                  ? Icons.check_circle_outline
+                  : Icons.science_outlined;
+          return ListTile(
+            leading: Icon(
+              icon,
+              color: result.updateAvailable
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+            ),
+            title: Text(title),
+            subtitle: Text(subtitle),
+            trailing: const Icon(Icons.open_in_new),
+            onTap: () => _openLatestRelease(result.releaseUri),
+          );
+        },
+      );
+
+  Future<UpdateCheckResult> _checkForUpdates() async {
+    final info = await _packageInfo;
+    return _updateCheckService.check(info.version);
+  }
+
+  void _retryUpdateCheck() {
+    setState(() => _updateCheck = _checkForUpdates());
+  }
+
+  Future<void> _openLatestRelease(Uri uri) async {
+    try {
+      final opened = await launchUrl(uri, mode: LaunchMode.externalApplication);
+      if (!opened) _message('无法打开 GitHub Release 页面');
+    } on Object {
+      _message('无法打开 GitHub Release 页面');
+    }
+  }
 
   Future<void> _saveSync() async {
     final connection = SyncConnection(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: netcatty_mobile
 description: Netcatty mobile SSH, SFTP and cloud-sync client for Android and iOS.
 publish_to: none
-version: 1.2.2+4
+version: 1.2.3+5
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/test/update_check_service_test.dart
+++ b/test/update_check_service_test.dart
@@ -1,0 +1,122 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:netcatty_mobile/infrastructure/update_check_service.dart';
+
+void main() {
+  test('matching app and v-prefixed release versions are latest', () async {
+    late http.Request captured;
+    final service = UpdateCheckService(
+      client: MockClient((request) async {
+        captured = request;
+        return http.Response(
+          jsonEncode({
+            'tag_name': 'v1.2.2',
+            'html_url':
+                'https://github.com/kmh1145/Netcatty-mobile/releases/tag/v1.2.2',
+          }),
+          200,
+        );
+      }),
+    );
+
+    final result = await service.check('1.2.2');
+
+    expect(captured.url, UpdateCheckService.latestReleaseApi);
+    expect(captured.headers['accept'], 'application/vnd.github+json');
+    expect(result.currentVersion, '1.2.2');
+    expect(result.latestVersion, '1.2.2');
+    expect(result.isLatest, isTrue);
+    expect(result.updateAvailable, isFalse);
+    expect(result.isDevelopmentVersion, isFalse);
+    expect(result.releaseUri.path, endsWith('/releases/tag/v1.2.2'));
+  });
+
+  test('newer GitHub release is reported as an available update', () async {
+    final service = UpdateCheckService(
+      client: MockClient((_) async => http.Response(
+            jsonEncode({
+              'tag_name': 'v1.3.0',
+              'html_url':
+                  'https://github.com/kmh1145/Netcatty-mobile/releases/tag/v1.3.0',
+            }),
+            200,
+          )),
+    );
+
+    final result = await service.check('1.2.2');
+
+    expect(result.isLatest, isFalse);
+    expect(result.updateAvailable, isTrue);
+    expect(result.isDevelopmentVersion, isFalse);
+  });
+
+  test('version newer than public release is treated as development', () async {
+    final service = UpdateCheckService(
+      client: MockClient((_) async => http.Response(
+            jsonEncode({
+              'tag_name': 'v1.2.2',
+              'html_url': 'https://example.com/untrusted-release',
+            }),
+            200,
+          )),
+    );
+
+    final result = await service.check('1.3.0');
+
+    expect(result.isLatest, isFalse);
+    expect(result.updateAvailable, isFalse);
+    expect(result.isDevelopmentVersion, isTrue);
+    expect(result.releaseUri, UpdateCheckService.latestReleasePage);
+  });
+
+  test('invalid release response produces a readable error', () async {
+    final service = UpdateCheckService(
+      client: MockClient((_) async => http.Response('{}', 200)),
+    );
+
+    await expectLater(
+      service.check('1.2.2'),
+      throwsA(
+        isA<UpdateCheckException>().having(
+          (error) => error.message,
+          'message',
+          contains('缺少版本号'),
+        ),
+      ),
+    );
+  });
+
+  test('network failure produces a retryable error', () async {
+    final service = UpdateCheckService(
+      client: MockClient((_) async {
+        throw http.ClientException('connection aborted');
+      }),
+    );
+
+    await expectLater(
+      service.check('1.2.2'),
+      throwsA(
+        isA<UpdateCheckException>().having(
+          (error) => error.message,
+          'message',
+          contains('无法连接 GitHub'),
+        ),
+      ),
+    );
+  });
+
+  test('release version comparison follows semantic ordering', () {
+    expect(compareReleaseVersions('v1.2.2', '1.2.2'), 0);
+    expect(compareReleaseVersions('1.10.0', '1.9.9'), greaterThan(0));
+    expect(compareReleaseVersions('2.0', '1.99.99'), greaterThan(0));
+    expect(compareReleaseVersions('1.2.2', '1.2.2-beta.1'), greaterThan(0));
+    expect(
+      compareReleaseVersions('1.2.2-beta.2', '1.2.2-beta.10'),
+      lessThan(0),
+    );
+    expect(compareReleaseVersions('1.2.2+4', '1.2.2+30'), 0);
+  });
+}


### PR DESCRIPTION
## 变更内容

- 在设置页底部增加“关于与更新”入口
- 通过 GitHub Latest Release API 比较当前 App 版本与最新正式版本
- 支持更新可用、已是最新、开发版本和检查失败重试等状态
- 点击结果可跳转至对应 GitHub Release 下载页面
- 增加语义版本比较和网络/响应异常测试
- 更新 README 与开发文档

## 用户影响

用户无需手动查看仓库版本，即可在 App 内确认是否存在新版本，并直接前往最新 Release 下载更新。

## 验证

- `flutter analyze --no-pub` 通过
- Flutter 全量测试 44/44 通过
- Android Debug APK 构建成功
- GitHub 实际 Latest Release API 检查成功
- `git diff --check` 通过
