### PR TITLE
fix: 修复第三方输入法回车与安全键盘状态

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -77,7 +77,7 @@ sequenceDiagram
   C->>T: 关闭 Shell、SSHClient 和相关资源
 ```
 
-`ActiveTerminalSession` 拥有认证后的 `SSHClient`、Shell Channel、xterm `Terminal` 和 `TerminalInputController`。后者把底部 Ctrl/Alt/Shift 的一次性修饰状态应用到下一次系统软键盘输入；移动端 TerminalView 启用删除检测以兼容 iOS 输入法的退格事件。SFTP、端口转发、服务器监控和系统管理复用这个 SSH Client，避免重复认证。因此：
+`ActiveTerminalSession` 拥有认证后的 `SSHClient`、Shell Channel、xterm2 `Terminal` 和 `TerminalInputController`。后者把底部 Ctrl/Alt/Shift 的一次性修饰状态应用到下一次系统软键盘输入；移动端 TerminalView 启用删除检测以兼容 iOS 输入法的退格事件。SFTP、端口转发、服务器监控和系统管理复用这个 SSH Client，避免重复认证。因此：
 
 - 关闭标签时必须先二次确认，再由 `SessionController` 统一释放资源。
 - 同一主机可以建立多个独立 `ActiveTerminalSession`，不能按主机 ID 去重。

--- a/lib/application/settings_controller.dart
+++ b/lib/application/settings_controller.dart
@@ -19,7 +19,18 @@ class SettingsController extends StateNotifier<AppSettings> {
   Future<void> load() async => state = await repository.loadSettings();
 
   Future<void> update(AppSettings value) async {
+    final previous = state;
     state = value;
-    await repository.saveSettings(value);
+    try {
+      await repository.saveSettings(value);
+    } catch (_) {
+      state = previous;
+      rethrow;
+    }
+  }
+
+  Future<void> updateTerminalSecureKeyboard(bool enabled) async {
+    final persisted = await repository.loadSettings();
+    await update(persisted.copyWith(terminalSecureKeyboard: enabled));
   }
 }

--- a/lib/infrastructure/ssh/ssh_service.dart
+++ b/lib/infrastructure/ssh/ssh_service.dart
@@ -4,7 +4,7 @@ import 'dart:io';
 
 import 'package:dartssh2/dartssh2.dart';
 import 'package:flutter/foundation.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 import '../../domain/models/host.dart';
 import '../../domain/models/server_stats.dart';

--- a/lib/infrastructure/ssh/terminal_picture_in_picture_service.dart
+++ b/lib/infrastructure/ssh/terminal_picture_in_picture_service.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/services.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 class TerminalPictureInPictureService {
   const TerminalPictureInPictureService._();

--- a/lib/presentation/localization/translations_en.dart
+++ b/lib/presentation/localization/translations_en.dart
@@ -236,6 +236,7 @@ const englishTranslations = <String, String>{
   '无法连接 GitHub，请检查网络后重试':
       'Unable to connect to GitHub. Check the network and retry.',
   '系统安全键盘': 'System secure keyboard',
+  '安全键盘设置保存失败：': 'Failed to save secure keyboard setting: ',
   "Catty Agent', '使用 OpenAI 兼容接口生成命令，执行前始终确认":
       "Catty Agent', 'Generate commands with an OpenAI-compatible API and always confirm before execution",
   '正在等待 GitHub 授权…': 'Waiting for GitHub authorization…',
@@ -606,6 +607,7 @@ const englishReplacements = <(String, String)>[
   ('选择深色主题', 'Choose dark theme'),
   ('搜索 62 种主题', 'Search 62 themes'),
   ('种可选', ' available'),
+  ('安全键盘设置保存失败：', 'Failed to save secure keyboard setting: '),
   ('外观设置已保存', 'Appearance settings saved'),
   ('AI 设置已保存', 'AI settings saved'),
   ('确认更新', 'Confirm update'),

--- a/lib/presentation/screens/settings_screen.dart
+++ b/lib/presentation/screens/settings_screen.dart
@@ -49,6 +49,7 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
   var uiThemeId = 'tokyo-night';
   var terminalFontSize = 14.0;
   var terminalSecureKeyboard = false;
+  var _savingTerminalSecureKeyboard = false;
   var language = 'zh-CN';
   var _loaded = false;
   var _busy = false;
@@ -206,8 +207,9 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
                           '使用系统密码键盘并关闭联想学习；终端快捷键仍可输入 Ctrl 组合键',
                         ),
                         value: terminalSecureKeyboard,
-                        onChanged: (value) =>
-                            setState(() => terminalSecureKeyboard = value),
+                        onChanged: _savingTerminalSecureKeyboard
+                            ? null
+                            : _setTerminalSecureKeyboard,
                       ),
                       const SizedBox(height: 8),
                       SegmentedButton<String>(
@@ -870,6 +872,27 @@ class _SettingsScreenState extends ConsumerState<SettingsScreen> {
           ),
         );
     _message('外观设置已保存');
+  }
+
+  Future<void> _setTerminalSecureKeyboard(bool value) async {
+    final previous = terminalSecureKeyboard;
+    setState(() {
+      terminalSecureKeyboard = value;
+      _savingTerminalSecureKeyboard = true;
+    });
+    try {
+      await ref
+          .read(settingsControllerProvider.notifier)
+          .updateTerminalSecureKeyboard(value);
+    } catch (error) {
+      if (!mounted) return;
+      setState(() => terminalSecureKeyboard = previous);
+      _message('安全键盘设置保存失败：$error');
+    } finally {
+      if (mounted) {
+        setState(() => _savingTerminalSecureKeyboard = false);
+      }
+    }
   }
 
   Future<void> _selectTheme(Brightness brightness) async {

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:netcatty_mobile/presentation/localization/localized_widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter/services.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 import '../../application/session_controller.dart';
 import '../../application/settings_controller.dart';

--- a/lib/presentation/screens/terminal_screen_pane.dart
+++ b/lib/presentation/screens/terminal_screen_pane.dart
@@ -167,7 +167,7 @@ class _TerminalPane extends StatefulWidget {
 
 class _TerminalPaneState extends State<_TerminalPane> {
   final _controller = TerminalController();
-  final _terminalViewKey = GlobalKey<TerminalViewState>();
+  var _terminalViewKey = GlobalKey<TerminalViewState>();
   final _terminalStackKey = GlobalKey();
   final _scrollController = ScrollController();
   Offset? _dragPointerToAnchor;
@@ -185,6 +185,11 @@ class _TerminalPaneState extends State<_TerminalPane> {
   @override
   void didUpdateWidget(covariant _TerminalPane oldWidget) {
     super.didUpdateWidget(oldWidget);
+    if (oldWidget.secureKeyboard != widget.secureKeyboard) {
+      // xterm keeps the platform TextInputConnection alive while the view is
+      // mounted. Recreate it so Android and iOS receive the new input type.
+      _terminalViewKey = GlobalKey<TerminalViewState>();
+    }
     if (oldWidget.session.terminal != widget.session.terminal) {
       oldWidget.session.terminal.removeListener(_onTerminalChanged);
       widget.session.terminal.addListener(_onTerminalChanged);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -866,14 +866,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.6.1"
-  xterm:
+  xterm2:
     dependency: "direct main"
     description:
-      name: xterm
-      sha256: "168dfedca77cba33fdb6f52e2cd001e9fde216e398e89335c19b524bb22da3a2"
+      name: xterm2
+      sha256: "0b62e7510b414329dfb6ce7dbcffcfe97cc5109033573cf0f4abca568dac8149"
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "5.2.0"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: netcatty_mobile
 description: Netcatty mobile SSH, SFTP and cloud-sync client for Android and iOS.
 publish_to: none
-version: 1.3.1+8
+version: 1.3.2+9
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   dartssh2: ^2.22.3
-  xterm: ^4.0.0
+  xterm2: 5.2.0
   flutter_riverpod: ^2.6.1
   go_router: ^16.0.0
   flutter_secure_storage: ^9.2.4

--- a/test/sftp_terminal_usability_test.dart
+++ b/test/sftp_terminal_usability_test.dart
@@ -9,7 +9,7 @@ import 'package:netcatty_mobile/infrastructure/ssh/ssh_service.dart';
 import 'package:netcatty_mobile/infrastructure/ssh/terminal_picture_in_picture_service.dart';
 import 'package:netcatty_mobile/presentation/home_shell.dart';
 import 'package:netcatty_mobile/presentation/widgets/terminal_special_keys.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 void main() {
   test('home navigation only hides for a fullscreen terminal', () {

--- a/test/terminal_connection_dialog_test.dart
+++ b/test/terminal_connection_dialog_test.dart
@@ -2,13 +2,15 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:netcatty_mobile/application/session_controller.dart';
+import 'package:netcatty_mobile/application/settings_controller.dart';
 import 'package:netcatty_mobile/application/vault_controller.dart';
 import 'package:netcatty_mobile/domain/models/host.dart';
+import 'package:netcatty_mobile/domain/models/settings.dart';
 import 'package:netcatty_mobile/infrastructure/ssh/ssh_service.dart';
 import 'package:netcatty_mobile/infrastructure/storage/vault_repository.dart';
 import 'package:netcatty_mobile/presentation/screens/terminal_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:xterm/xterm.dart';
+import 'package:xterm2/xterm.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -157,6 +159,69 @@ void main() {
       expect(find.byTooltip('退出全屏'), findsOneWidget);
     },
   );
+
+  testWidgets('secure keyboard change recreates and persists the IME mode',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final repository = await VaultRepository.open();
+    await repository.saveSettings(
+      const AppSettings(uiThemeId: 'catppuccin', terminalFontSize: 18),
+    );
+    final settingsController = _SeededSettingsController(repository);
+    final host = _host('secure', '安全终端');
+    final session = ActiveTerminalSession(
+      id: 'secure-session',
+      host: host,
+      terminal: Terminal(),
+      verifyHostKey: _acceptHostKey,
+      keyboardInteractive: null,
+    );
+    final initialState = SessionState(sessions: [session]);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vaultRepositoryProvider.overrideWithValue(repository),
+          settingsControllerProvider.overrideWith(
+            (ref) => settingsController,
+          ),
+          sessionControllerProvider.overrideWith(
+            (ref) => _SeededSessionController(
+              ref.read(vaultControllerProvider.notifier),
+              ref,
+              initialState,
+            ),
+          ),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(body: TerminalScreen()),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    final normalView = find.byType(TerminalView);
+    expect(
+      tester.widget<TerminalView>(normalView).keyboardType,
+      TextInputType.emailAddress,
+    );
+    final normalState = tester.state<TerminalViewState>(normalView);
+
+    await settingsController.updateTerminalSecureKeyboard(true);
+    await tester.pump();
+
+    final secureView = find.byType(TerminalView);
+    expect(
+      tester.widget<TerminalView>(secureView).keyboardType,
+      TextInputType.visiblePassword,
+    );
+    expect(
+        tester.state<TerminalViewState>(secureView), isNot(same(normalState)));
+    final persisted = await repository.loadSettings();
+    expect(persisted.terminalSecureKeyboard, isTrue);
+    expect(persisted.uiThemeId, 'catppuccin');
+    expect(persisted.terminalFontSize, 18);
+  });
 }
 
 class _SeededSessionController extends SessionController {
@@ -166,6 +231,12 @@ class _SeededSessionController extends SessionController {
     SessionState initialState,
   ) : super(SshService(), vaultController, ref) {
     state = initialState;
+  }
+}
+
+class _SeededSettingsController extends SettingsController {
+  _SeededSettingsController(super.repository) {
+    state = const AppSettings();
   }
 }
 

--- a/test/terminal_input_controller_test.dart
+++ b/test/terminal_input_controller_test.dart
@@ -1,5 +1,7 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:netcatty_mobile/infrastructure/ssh/ssh_service.dart';
+import 'package:xterm2/xterm.dart';
 
 void main() {
   test('Ctrl modifier transforms the next soft-keyboard character', () {
@@ -22,5 +24,26 @@ void main() {
 
     expect(input.consume(''), '');
     expect(input.modifiers, {'ctrl'});
+  });
+
+  testWidgets('third-party IME newline action sends terminal enter',
+      (tester) async {
+    final output = <String>[];
+    final terminal = Terminal()..onOutput = output.add;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: TerminalView(terminal, autofocus: true),
+        ),
+      ),
+    );
+    await tester.pump();
+
+    expect(tester.testTextInput.isVisible, isTrue);
+    await tester.testTextInput.receiveAction(TextInputAction.newline);
+    await tester.pump();
+
+    expect(output, contains('\r'));
   });
 }


### PR DESCRIPTION
修复 Android 部分第三方输入法无法通过回车执行命令的问题，并修复 Android/iOS 安全键盘设置在重新进入连接后偶尔失效的问题。安全键盘设置现会立即持久化，切换后重建输入连接，并在保存失败时回滚。已通过 flutter analyze、57 项全量测试和 Android Release APK 本地构建。此 PR 将触发 Android APK 与未签名 iOS IPA 的 Actions 构建，供受影响用户安装测试。