### PR TITLE
feat: 强化后台 SSH 保活并支持删除片段

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
@@ -39,6 +40,7 @@
         <service
             android:name=".SshKeepAliveService"
             android:exported="false"
+            android:stopWithTask="false"
             android:foregroundServiceType="specialUse">
             <property
                 android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"

--- a/android/app/src/main/kotlin/app/netcatty/mobile/SshKeepAliveService.kt
+++ b/android/app/src/main/kotlin/app/netcatty/mobile/SshKeepAliveService.kt
@@ -1,13 +1,17 @@
 package app.netcatty.mobile
 
+import android.annotation.SuppressLint
 import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
+import android.content.Context
 import android.content.Intent
+import android.net.wifi.WifiManager
 import android.os.Build
 import android.os.IBinder
+import android.os.PowerManager
 
 class SshKeepAliveService : Service() {
     companion object {
@@ -15,16 +19,62 @@ class SshKeepAliveService : Service() {
         private const val NOTIFICATION_ID = 701
     }
 
+    private var cpuWakeLock: PowerManager.WakeLock? = null
+    private var wifiLock: WifiManager.WifiLock? = null
+
     override fun onCreate() {
         super.onCreate()
         createChannel()
         startForeground(NOTIFICATION_ID, buildNotification())
+        acquireConnectionLocks()
     }
 
-    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int =
-        START_STICKY
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        acquireConnectionLocks()
+        // The SSH sockets live in the Flutter process. Restarting only this
+        // service after that process was killed cannot restore them and would
+        // leave an orphan notification holding locks indefinitely.
+        return START_NOT_STICKY
+    }
 
     override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        releaseConnectionLocks()
+        super.onDestroy()
+    }
+
+    @SuppressLint("WakelockTimeout")
+    private fun acquireConnectionLocks() {
+        if (cpuWakeLock?.isHeld != true) {
+            cpuWakeLock = (getSystemService(Context.POWER_SERVICE) as PowerManager)
+                .newWakeLock(
+                    PowerManager.PARTIAL_WAKE_LOCK,
+                    "$packageName:ssh-cpu",
+                ).apply {
+                    setReferenceCounted(false)
+                    acquire()
+                }
+        }
+        if (wifiLock?.isHeld != true) {
+            @Suppress("DEPRECATION")
+            wifiLock = (applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager)
+                .createWifiLock(
+                    WifiManager.WIFI_MODE_FULL_HIGH_PERF,
+                    "$packageName:ssh-wifi",
+                ).apply {
+                    setReferenceCounted(false)
+                    acquire()
+                }
+        }
+    }
+
+    private fun releaseConnectionLocks() {
+        cpuWakeLock?.let { if (it.isHeld) it.release() }
+        cpuWakeLock = null
+        wifiLock?.let { if (it.isHeld) it.release() }
+        wifiLock = null
+    }
 
     private fun createChannel() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,6 +8,7 @@ import UIKit
 @main
 @objc class AppDelegate: FlutterAppDelegate, FlutterImplicitEngineDelegate {
   private var sshBackgroundTask: UIBackgroundTaskIdentifier = .invalid
+  private let sshBackgroundAudioKeeper = SshBackgroundAudioKeeper()
   private var pictureInPictureChannel: FlutterMethodChannel?
   private var terminalPictureInPictureStorage: AnyObject?
 
@@ -33,6 +34,11 @@ import UIKit
         self?.endSshBackgroundGrace()
         result(nil)
       case "setActive":
+        let active = (call.arguments as? [String: Any])?["active"] as? Bool ?? false
+        self?.sshBackgroundAudioKeeper.setActive(
+          active,
+          deactivateSessionWhenStopping: self?.isTerminalPictureInPictureActive != true
+        )
         result(nil)
       default:
         result(FlutterMethodNotImplemented)
@@ -101,6 +107,9 @@ import UIKit
       } else if UIApplication.shared.applicationState != .active {
         self.beginSshBackgroundGrace()
       }
+      if !active {
+        self.sshBackgroundAudioKeeper.resumeIfNeeded()
+      }
     }
     terminalPictureInPictureStorage = controller
     return controller
@@ -129,6 +138,7 @@ import UIKit
 
   private func beginSshBackgroundGrace() {
     guard !isTerminalPictureInPictureActive else { return }
+    guard !sshBackgroundAudioKeeper.isRunning else { return }
     guard sshBackgroundTask == .invalid else { return }
     sshBackgroundTask = UIApplication.shared.beginBackgroundTask(
       withName: "Finish active SSH network work"
@@ -148,8 +158,134 @@ import UIKit
        let controller = terminalPictureInPictureStorage as? TerminalPictureInPictureController {
       controller.stop()
     }
+    sshBackgroundAudioKeeper.setActive(false, deactivateSessionWhenStopping: true)
     endSshBackgroundGrace()
     super.applicationWillTerminate(application)
+  }
+}
+
+private final class SshBackgroundAudioKeeper {
+  private var engine = AVAudioEngine()
+  private var sourceNode: AVAudioSourceNode?
+  private var desiredActive = false
+  private var observers: [NSObjectProtocol] = []
+
+  init() {
+    let center = NotificationCenter.default
+    observers.append(
+      center.addObserver(
+        forName: AVAudioSession.interruptionNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] notification in
+        self?.handleInterruption(notification)
+      }
+    )
+    observers.append(
+      center.addObserver(
+        forName: AVAudioSession.mediaServicesWereResetNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        self?.rebuildAndResume()
+      }
+    )
+    observers.append(
+      center.addObserver(
+        forName: AVAudioSession.routeChangeNotification,
+        object: nil,
+        queue: .main
+      ) { [weak self] _ in
+        self?.resumeIfNeeded()
+      }
+    )
+  }
+
+  deinit {
+    observers.forEach { NotificationCenter.default.removeObserver($0) }
+  }
+
+  var isRunning: Bool {
+    desiredActive && engine.isRunning
+  }
+
+  func setActive(_ active: Bool, deactivateSessionWhenStopping: Bool) {
+    desiredActive = active
+    if active {
+      start()
+    } else {
+      stop(deactivateSession: deactivateSessionWhenStopping)
+    }
+  }
+
+  func resumeIfNeeded() {
+    guard desiredActive else { return }
+    start()
+  }
+
+  private func start() {
+    guard desiredActive else { return }
+    let session = AVAudioSession.sharedInstance()
+    do {
+      try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+      try session.setActive(true)
+      if sourceNode == nil {
+        let source = AVAudioSourceNode { _, _, _, audioBufferList -> OSStatus in
+          let buffers = UnsafeMutableAudioBufferListPointer(audioBufferList)
+          for buffer in buffers {
+            if let data = buffer.mData {
+              memset(data, 0, Int(buffer.mDataByteSize))
+            }
+          }
+          return noErr
+        }
+        sourceNode = source
+        engine.attach(source)
+        let format = AVAudioFormat(
+          standardFormatWithSampleRate: 44_100,
+          channels: 1
+        )
+        engine.connect(source, to: engine.mainMixerNode, format: format)
+      }
+      if !engine.isRunning {
+        engine.prepare()
+        try engine.start()
+      }
+    } catch {
+      // Calls, route changes, and media resets may temporarily deny activation.
+      // Their notifications retry the engine when the audio route is available.
+    }
+  }
+
+  private func stop(deactivateSession: Bool) {
+    if engine.isRunning {
+      engine.stop()
+    }
+    if deactivateSession {
+      try? AVAudioSession.sharedInstance().setActive(
+        false,
+        options: [.notifyOthersOnDeactivation]
+      )
+    }
+  }
+
+  private func rebuildAndResume() {
+    guard desiredActive else { return }
+    engine.stop()
+    engine = AVAudioEngine()
+    sourceNode = nil
+    start()
+  }
+
+  private func handleInterruption(_ notification: Notification) {
+    guard desiredActive,
+          let rawType = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+          let type = AVAudioSession.InterruptionType(rawValue: rawType) else { return }
+    if type == .ended {
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+        self?.resumeIfNeeded()
+      }
+    }
   }
 }
 
@@ -169,6 +305,8 @@ private final class TerminalPictureInPictureController: NSObject {
   private var lastFrameSignature: Int?
   private var pixelBufferPool: CVPixelBufferPool?
   private var formatDescription: CMVideoFormatDescription?
+  private var latestPixelBuffer: CVPixelBuffer?
+  private var frameHeartbeatTimer: Timer?
 
   init(onStateChanged: @escaping (Bool) -> Void) {
     self.onStateChanged = onStateChanged
@@ -262,6 +400,7 @@ private final class TerminalPictureInPictureController: NSObject {
             ) else { return }
       DispatchQueue.main.async { [weak self] in
         guard let self, generation == self.renderGeneration else { return }
+        self.latestPixelBuffer = pixelBuffer
         self.enqueue(pixelBuffer)
       }
     }
@@ -271,6 +410,7 @@ private final class TerminalPictureInPictureController: NSObject {
     renderGeneration += 1
     lastFrameSignature = nil
     starting = false
+    stopFrameHeartbeat()
     finishStart(false)
     if pictureInPictureController?.isPictureInPictureActive == true {
       pictureInPictureController?.stopPictureInPicture()
@@ -485,6 +625,24 @@ private final class TerminalPictureInPictureController: NSObject {
     displayLayer.enqueue(sampleBuffer)
   }
 
+  private func startFrameHeartbeat() {
+    guard frameHeartbeatTimer == nil else { return }
+    let timer = Timer(timeInterval: 1, repeats: true) { [weak self] _ in
+      guard let self,
+            self.pictureInPictureController?.isPictureInPictureActive == true,
+            let pixelBuffer = self.latestPixelBuffer else { return }
+      self.enqueue(pixelBuffer)
+    }
+    RunLoop.main.add(timer, forMode: .common)
+    frameHeartbeatTimer = timer
+  }
+
+  private func stopFrameHeartbeat() {
+    frameHeartbeatTimer?.invalidate()
+    frameHeartbeatTimer = nil
+    latestPixelBuffer = nil
+  }
+
   private func uiColor(_ value: Any?, fallback: UInt32) -> UIColor {
     let raw = UInt32(truncating: value as? NSNumber ?? NSNumber(value: fallback))
     return UIColor(
@@ -541,6 +699,7 @@ extension TerminalPictureInPictureController: AVPictureInPictureControllerDelega
     _ pictureInPictureController: AVPictureInPictureController
   ) {
     starting = false
+    startFrameHeartbeat()
     finishStart(true)
     onStateChanged(true)
   }
@@ -550,6 +709,7 @@ extension TerminalPictureInPictureController: AVPictureInPictureControllerDelega
     failedToStartPictureInPictureWithError error: Error
   ) {
     starting = false
+    stopFrameHeartbeat()
     finishStart(false)
     detachSource()
     deactivatePlaybackSession()
@@ -560,6 +720,7 @@ extension TerminalPictureInPictureController: AVPictureInPictureControllerDelega
     _ pictureInPictureController: AVPictureInPictureController
   ) {
     starting = false
+    stopFrameHeartbeat()
     finishStart(false)
     detachSource()
     deactivatePlaybackSession()

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -297,6 +297,9 @@ private final class TerminalPictureInPictureController: NSObject {
   private var pictureInPictureController: AVPictureInPictureController?
   private var startCompletion: ((Bool) -> Void)?
   private var starting = false
+  private var startGeneration = 0
+  private var startAttemptsRunning = false
+  private var automaticStartRetries = 0
   private let renderQueue = DispatchQueue(
     label: "app.netcatty.mobile.pip-render",
     qos: .utility
@@ -340,25 +343,26 @@ private final class TerminalPictureInPictureController: NSObject {
       return
     }
     attachSource(to: sourceView)
-    update(arguments: arguments)
     configurePlaybackSession()
-    if pictureInPictureController == nil {
-      let source = AVPictureInPictureController.ContentSource(
-        sampleBufferDisplayLayer: displayLayer,
-        playbackDelegate: self
-      )
-      let controller = AVPictureInPictureController(contentSource: source)
-      controller.delegate = self
-      controller.requiresLinearPlayback = true
-      controller.canStartPictureInPictureAutomaticallyFromInline = false
-      pictureInPictureController = controller
-    }
+    configurePictureInPictureController()
     starting = true
+    startGeneration += 1
+    let generation = startGeneration
+    startAttemptsRunning = false
+    automaticStartRetries = 0
     startCompletion = completion
-    attemptStart(remainingAttempts: 20)
+    update(arguments: arguments) { [weak self] in
+      self?.beginStartAttempts(generation: generation)
+    }
+    // Rendering the first 960x540 terminal frame happens off the main thread.
+    // Keep a fallback in case rendering fails, but normally the first queued
+    // sample buffer starts the PiP readiness checks immediately.
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.75) { [weak self] in
+      self?.beginStartAttempts(generation: generation)
+    }
   }
 
-  func update(arguments: [String: Any]) {
+  func update(arguments: [String: Any], completion: (() -> Void)? = nil) {
     let title = (arguments["title"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines)
     let text = arguments["text"] as? String ?? ""
     let connected = arguments["connected"] as? Bool ?? false
@@ -384,7 +388,12 @@ private final class TerminalPictureInPictureController: NSObject {
     hasher.combine(arguments["foregroundColor"] as? Int ?? 0)
     hasher.combine(arguments["accentColor"] as? Int ?? 0)
     let signature = hasher.finalize()
-    guard signature != lastFrameSignature else { return }
+    guard signature != lastFrameSignature else {
+      if latestPixelBuffer != nil {
+        completion?()
+      }
+      return
+    }
     lastFrameSignature = signature
     renderGeneration += 1
     let generation = renderGeneration
@@ -402,6 +411,7 @@ private final class TerminalPictureInPictureController: NSObject {
         guard let self, generation == self.renderGeneration else { return }
         self.latestPixelBuffer = pixelBuffer
         self.enqueue(pixelBuffer)
+        completion?()
       }
     }
   }
@@ -410,6 +420,9 @@ private final class TerminalPictureInPictureController: NSObject {
     renderGeneration += 1
     lastFrameSignature = nil
     starting = false
+    startGeneration += 1
+    startAttemptsRunning = false
+    automaticStartRetries = 0
     stopFrameHeartbeat()
     finishStart(false)
     if pictureInPictureController?.isPictureInPictureActive == true {
@@ -444,29 +457,77 @@ private final class TerminalPictureInPictureController: NSObject {
     )
   }
 
-  private func attemptStart(remainingAttempts: Int) {
-    guard starting, let controller = pictureInPictureController else { return }
+  private func configurePictureInPictureController() {
+    guard pictureInPictureController == nil else { return }
+    let source = AVPictureInPictureController.ContentSource(
+      sampleBufferDisplayLayer: displayLayer,
+      playbackDelegate: self
+    )
+    let controller = AVPictureInPictureController(contentSource: source)
+    controller.delegate = self
+    controller.requiresLinearPlayback = true
+    controller.canStartPictureInPictureAutomaticallyFromInline = false
+    pictureInPictureController = controller
+  }
+
+  private func beginStartAttempts(generation: Int) {
+    guard starting,
+          generation == startGeneration,
+          !startAttemptsRunning else { return }
+    startAttemptsRunning = true
+    attemptStart(generation: generation, remainingAttempts: 60)
+  }
+
+  private func attemptStart(generation: Int, remainingAttempts: Int) {
+    guard starting,
+          generation == startGeneration,
+          let controller = pictureInPictureController else { return }
     if controller.isPictureInPicturePossible {
       controller.startPictureInPicture()
-      DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
-        guard let self, self.starting else { return }
-        self.starting = false
-        self.finishStart(false)
-        self.onStateChanged(false)
+      DispatchQueue.main.asyncAfter(deadline: .now() + 4) { [weak self, weak controller] in
+        guard let self,
+              let controller,
+              self.starting,
+              generation == self.startGeneration,
+              self.pictureInPictureController === controller,
+              !controller.isPictureInPictureActive else { return }
+        self.retryOrFinishStart(generation: generation)
       }
       return
     }
     guard remainingAttempts > 0 else {
-      starting = false
-      finishStart(false)
-      detachSource()
-      deactivatePlaybackSession()
-      onStateChanged(false)
+      retryOrFinishStart(generation: generation)
       return
     }
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
-      self?.attemptStart(remainingAttempts: remainingAttempts - 1)
+      self?.attemptStart(
+        generation: generation,
+        remainingAttempts: remainingAttempts - 1
+      )
     }
+  }
+
+  private func retryOrFinishStart(generation: Int) {
+    guard starting, generation == startGeneration else { return }
+    if automaticStartRetries < 1 {
+      automaticStartRetries += 1
+      startAttemptsRunning = false
+      let previousController = pictureInPictureController
+      previousController?.delegate = nil
+      previousController?.stopPictureInPicture()
+      pictureInPictureController = nil
+      configurePictureInPictureController()
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) { [weak self] in
+        self?.beginStartAttempts(generation: generation)
+      }
+      return
+    }
+    starting = false
+    startAttemptsRunning = false
+    finishStart(false)
+    detachSource()
+    deactivatePlaybackSession()
+    onStateChanged(false)
   }
 
   private func finishStart(_ entered: Bool) {
@@ -699,6 +760,7 @@ extension TerminalPictureInPictureController: AVPictureInPictureControllerDelega
     _ pictureInPictureController: AVPictureInPictureController
   ) {
     starting = false
+    startAttemptsRunning = false
     startFrameHeartbeat()
     finishStart(true)
     onStateChanged(true)
@@ -708,18 +770,15 @@ extension TerminalPictureInPictureController: AVPictureInPictureControllerDelega
     _ pictureInPictureController: AVPictureInPictureController,
     failedToStartPictureInPictureWithError error: Error
   ) {
-    starting = false
-    stopFrameHeartbeat()
-    finishStart(false)
-    detachSource()
-    deactivatePlaybackSession()
-    onStateChanged(false)
+    guard self.pictureInPictureController === pictureInPictureController else { return }
+    retryOrFinishStart(generation: startGeneration)
   }
 
   func pictureInPictureControllerDidStopPictureInPicture(
     _ pictureInPictureController: AVPictureInPictureController
   ) {
     starting = false
+    startAttemptsRunning = false
     stopFrameHeartbeat()
     finishStart(false)
     detachSource()

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -34,11 +34,14 @@ class _NetcattyAppState extends ConsumerState<NetcattyApp>
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       ConnectionPlatformService.endBackgroundGrace();
-      ref.read(sessionControllerProvider.notifier).reconnectDisconnected();
+      ref.read(sessionControllerProvider.notifier).setBackgrounded(false);
     } else if (state == AppLifecycleState.inactive ||
         state == AppLifecycleState.paused ||
         state == AppLifecycleState.hidden) {
       ConnectionPlatformService.beginBackgroundGrace();
+      if (state != AppLifecycleState.inactive) {
+        ref.read(sessionControllerProvider.notifier).setBackgrounded(true);
+      }
     }
   }
 
@@ -46,7 +49,15 @@ class _NetcattyAppState extends ConsumerState<NetcattyApp>
   Widget build(BuildContext context) {
     ref.listen<bool>(
       sessionControllerProvider.select(
-        (value) => value.sessions.any((session) => session.connected),
+        // Start while the user-initiated connection is still in the foreground;
+        // Android 12+ can reject a service first started after the app is hidden.
+        // A disconnected tab also keeps it alive so recovery retains CPU time.
+        (value) =>
+            value.sessions.isNotEmpty ||
+            value.pendingConnections.any(
+              (connection) =>
+                  connection.phase == PendingConnectionPhase.connecting,
+            ),
       ),
       (previous, next) => ConnectionPlatformService.setActive(next),
     );

--- a/lib/application/session_controller.dart
+++ b/lib/application/session_controller.dart
@@ -102,6 +102,21 @@ class SessionController extends StateNotifier<SessionState> {
   final VaultController vaultController;
   final Ref ref;
   bool _reconnecting = false;
+  bool _backgrounded = false;
+  bool _backgroundMaintenanceRunning = false;
+  Timer? _backgroundMaintenanceTimer;
+  DateTime? _nextBackgroundReconnect;
+  int _backgroundReconnectAttempt = 0;
+
+  static const _backgroundMaintenanceInterval = Duration(seconds: 8);
+  static const _backgroundReconnectDelays = <Duration>[
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 5),
+    Duration(seconds: 10),
+    Duration(seconds: 15),
+    Duration(seconds: 30),
+  ];
 
   Future<void> connect(
     HostProfile host,
@@ -144,6 +159,7 @@ class SessionController extends StateNotifier<SessionState> {
         error: null,
       );
       _watchSession(session);
+      _ensureBackgroundMaintenance();
       if (connectionHost.data['_ephemeralTerminal'] == true) {
         session.systemInfo = connectionHost.systemInfo;
       } else {
@@ -222,6 +238,8 @@ class SessionController extends StateNotifier<SessionState> {
             error: null,
           );
           _watchSession(replacement);
+          _backgroundReconnectAttempt = 0;
+          _nextBackgroundReconnect = null;
           unawaited(_detectSystem(replacement, old.host));
         } catch (error) {
           old.terminal.write('\r\n\x1b[31m恢复连接失败：$error\x1b[0m\r\n');
@@ -235,14 +253,88 @@ class SessionController extends StateNotifier<SessionState> {
 
   void _watchSession(ActiveTerminalSession session) {
     unawaited(session.done.then((_) {
-      if (session.closedByUser) return;
-      session.connected = false;
-      session.terminal.write('\r\n\x1b[33m连接已断开，返回前台后将自动重连。\x1b[0m\r\n');
-      if (!mounted) return;
-      state = state.copyWith(
-        sessions: [...state.sessions],
-      );
+      _markDisconnected(session);
     }));
+  }
+
+  void setBackgrounded(bool backgrounded) {
+    if (_backgrounded == backgrounded) return;
+    _backgrounded = backgrounded;
+    if (backgrounded) {
+      _ensureBackgroundMaintenance();
+      unawaited(_maintainBackgroundConnections());
+      return;
+    }
+    _backgroundMaintenanceTimer?.cancel();
+    _backgroundMaintenanceTimer = null;
+    _backgroundReconnectAttempt = 0;
+    _nextBackgroundReconnect = null;
+    unawaited(reconnectDisconnected());
+  }
+
+  void _ensureBackgroundMaintenance() {
+    if (!_backgrounded || state.sessions.isEmpty) return;
+    _backgroundMaintenanceTimer ??= Timer.periodic(
+      _backgroundMaintenanceInterval,
+      (_) => unawaited(_maintainBackgroundConnections()),
+    );
+  }
+
+  Future<void> _maintainBackgroundConnections() async {
+    if (!_backgrounded || _backgroundMaintenanceRunning || !mounted) return;
+    _backgroundMaintenanceRunning = true;
+    try {
+      for (final session in [...state.sessions]) {
+        if (!session.connected || session.closedByUser) continue;
+        try {
+          await session.ping();
+        } on Object {
+          _markDisconnected(session);
+          session.abort();
+        }
+      }
+      if (!state.sessions.any(
+        (session) => !session.connected && !session.closedByUser,
+      )) {
+        _backgroundReconnectAttempt = 0;
+        _nextBackgroundReconnect = null;
+        return;
+      }
+      final now = DateTime.now();
+      final next = _nextBackgroundReconnect;
+      if (next != null && now.isBefore(next)) return;
+      await reconnectDisconnected();
+      if (state.sessions.any(
+        (session) => !session.connected && !session.closedByUser,
+      )) {
+        final delay =
+            _backgroundReconnectDelays[_backgroundReconnectAttempt.clamp(
+          0,
+          _backgroundReconnectDelays.length - 1,
+        )];
+        _backgroundReconnectAttempt++;
+        _nextBackgroundReconnect = DateTime.now().add(delay);
+      } else {
+        _backgroundReconnectAttempt = 0;
+        _nextBackgroundReconnect = null;
+      }
+    } finally {
+      _backgroundMaintenanceRunning = false;
+    }
+  }
+
+  void _markDisconnected(ActiveTerminalSession session) {
+    if (session.closedByUser || !session.connected) return;
+    session.connected = false;
+    session.terminal.write(
+      _backgrounded
+          ? '\r\n\x1b[33m连接已断开，正在后台自动恢复…\x1b[0m\r\n'
+          : '\r\n\x1b[33m连接已断开，返回前台后将自动重连。\x1b[0m\r\n',
+    );
+    if (!mounted) return;
+    state = state.copyWith(sessions: [...state.sessions]);
+    _ensureBackgroundMaintenance();
+    if (_backgrounded) unawaited(_maintainBackgroundConnections());
   }
 
   Future<void> _detectSystem(
@@ -315,11 +407,21 @@ class SessionController extends StateNotifier<SessionState> {
       activeIndex:
           sessions.isEmpty ? 0 : activeIndex.clamp(0, sessions.length - 1),
     );
+    if (sessions.isEmpty) {
+      _backgroundMaintenanceTimer?.cancel();
+      _backgroundMaintenanceTimer = null;
+    }
   }
 
   void send(String text, {bool enter = false}) {
     final session = state.active;
     if (session == null) return;
     session.terminal.textInput(enter ? '$text\r' : text);
+  }
+
+  @override
+  void dispose() {
+    _backgroundMaintenanceTimer?.cancel();
+    super.dispose();
   }
 }

--- a/lib/infrastructure/ssh/ssh_service.dart
+++ b/lib/infrastructure/ssh/ssh_service.dart
@@ -95,6 +95,25 @@ class ActiveTerminalSession {
   Future<void> get done =>
       sshSession?.done ?? telnetSocket?.done ?? Future.value();
 
+  Future<void> ping({Duration timeout = const Duration(seconds: 8)}) async {
+    if (!connected) throw StateError('SSH session is disconnected');
+    if (sshClients.isNotEmpty) {
+      await Future.wait(sshClients.map((client) => client.ping()))
+          .timeout(timeout);
+      return;
+    }
+    await telnetSocket?.flush().timeout(timeout);
+  }
+
+  void abort() {
+    connected = false;
+    sshSession?.close();
+    for (final client in sshClients.reversed) {
+      client.close();
+    }
+    telnetSocket?.destroy();
+  }
+
   Future<void> close() async {
     closedByUser = true;
     connected = false;

--- a/lib/presentation/localization/translations_en.dart
+++ b/lib/presentation/localization/translations_en.dart
@@ -143,6 +143,8 @@ const englishTranslations = <String, String>{
   '新建片段': 'New snippet',
   '新建命令片段': 'New command snippet',
   '编辑命令片段': 'Edit command snippet',
+  '片段操作': 'Snippet actions',
+  '删除命令片段？': 'Delete command snippet?',
   '发送后立即执行': 'Execute immediately after sending',
   '请先建立终端会话': 'Connect a terminal session first',
   '双栏文件传输': 'Dual-pane file transfer',
@@ -311,6 +313,10 @@ const englishReplacements = <(String, String)>[
     'GitHub sign-in succeeded. Netcatty will find the Gist automatically'
   ),
   ('网络连接发生变化，正在自动重试', 'The network changed; retrying automatically'),
+  (
+    '连接已断开，正在后台自动恢复',
+    'The connection was closed; reconnecting in the background'
+  ),
   ('连接已断开', 'The connection was closed'),
   ('正在恢复连接', 'Reconnecting'),
   ('恢复连接失败', 'Reconnection failed'),
@@ -331,6 +337,8 @@ const englishReplacements = <(String, String)>[
   ('将移除', 'Remove '),
   ('将断开', 'Disconnect '),
   ('将从保险库中删除', 'Delete from the vault: '),
+  ('将删除“', 'Delete “'),
+  ('”，此操作可通过云同步传播到其他设备。', '”. This change can sync to other devices.'),
   ('重新创建有变化的服务', 'recreate changed services'),
   ('使用当前镜像重新创建', 'recreate using the current image'),
   ('强制创建全部容器', 'force-recreate all containers'),

--- a/lib/presentation/localization/translations_en.dart
+++ b/lib/presentation/localization/translations_en.dart
@@ -402,8 +402,8 @@ const englishReplacements = <(String, String)>[
     'Terminal Picture in Picture is unavailable on this device or OS version'
   ),
   (
-    '无法启动画中画，请检查系统画中画权限',
-    'Unable to start Picture in Picture. Check the system permission'
+    '画中画初始化失败，请稍后重试',
+    'Picture in Picture initialization failed. Try again shortly'
   ),
   ('无法打开 GitHub Release 页面', 'Unable to open the GitHub Release page'),
   ('正在查询 GitHub 最新 Release', 'Checking the latest GitHub Release'),

--- a/lib/presentation/screens/snippets_screen.dart
+++ b/lib/presentation/screens/snippets_screen.dart
@@ -71,9 +71,50 @@ class SnippetsScreen extends ConsumerWidget {
                           );
                         }
                       },
-                      trailing: IconButton(
-                        onPressed: () => _edit(context, ref, snippet),
-                        icon: const Icon(Icons.edit_outlined),
+                      trailing: PopupMenuButton<_SnippetAction>(
+                        key: ValueKey('snippet-actions-${snippet.id}'),
+                        tooltip: localized('片段操作'),
+                        onSelected: (action) async {
+                          switch (action) {
+                            case _SnippetAction.edit:
+                              await _edit(context, ref, snippet);
+                              break;
+                            case _SnippetAction.delete:
+                              await _delete(context, ref, snippet);
+                              break;
+                          }
+                        },
+                        itemBuilder: (context) => [
+                          const PopupMenuItem(
+                            value: _SnippetAction.edit,
+                            child: Row(
+                              children: [
+                                Icon(Icons.edit_outlined),
+                                SizedBox(width: 12),
+                                LText('编辑'),
+                              ],
+                            ),
+                          ),
+                          PopupMenuItem(
+                            key: ValueKey('delete-snippet-${snippet.id}'),
+                            value: _SnippetAction.delete,
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.delete_outline,
+                                  color: Theme.of(context).colorScheme.error,
+                                ),
+                                const SizedBox(width: 12),
+                                LText(
+                                  '删除',
+                                  style: TextStyle(
+                                    color: Theme.of(context).colorScheme.error,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
                       ),
                     ),
                   );
@@ -169,4 +210,52 @@ class SnippetsScreen extends ConsumerWidget {
         .read(vaultControllerProvider.notifier)
         .replace(vault.copyWith(snippets: list));
   }
+
+  Future<void> _delete(
+    BuildContext context,
+    WidgetRef ref,
+    CommandSnippet snippet,
+  ) async {
+    final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            icon: Icon(
+              Icons.delete_outline,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            title: const LText('删除命令片段？'),
+            content: LText(
+              '将删除“${snippet.label}”，此操作可通过云同步传播到其他设备。',
+            ),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const LText('取消'),
+              ),
+              FilledButton(
+                key: const ValueKey('confirm-delete-snippet'),
+                onPressed: () => Navigator.pop(context, true),
+                style: FilledButton.styleFrom(
+                  backgroundColor: Theme.of(context).colorScheme.error,
+                  foregroundColor: Theme.of(context).colorScheme.onError,
+                ),
+                child: const LText('删除'),
+              ),
+            ],
+          ),
+        ) ??
+        false;
+    if (!confirmed) return;
+    final controller = ref.read(vaultControllerProvider.notifier);
+    final vault = await controller.ready();
+    await controller.replace(
+      vault.copyWith(
+        snippets: vault.snippets
+            .where((value) => value.id != snippet.id)
+            .toList(growable: false),
+      ),
+    );
+  }
 }
+
+enum _SnippetAction { edit, delete }

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -385,7 +385,7 @@ class _TerminalScreenState extends ConsumerState<TerminalScreen> {
     if (entered || !mounted) return;
     ref.read(terminalPictureInPictureProvider.notifier).state = false;
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: LText('无法启动画中画，请检查系统画中画权限')),
+      const SnackBar(content: LText('画中画初始化失败，请稍后重试')),
     );
   }
 

--- a/test/snippets_screen_test.dart
+++ b/test/snippets_screen_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:netcatty_mobile/infrastructure/storage/vault_repository.dart';
+import 'package:netcatty_mobile/presentation/screens/snippets_screen.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('snippet can be deleted after confirmation', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'netcatty_mobile_vault_v1': jsonEncode({
+        'hosts': const [],
+        'keys': const [],
+        'snippets': [
+          {
+            'id': 'snippet-1',
+            'label': 'Disk usage',
+            'command': 'df -h',
+          },
+        ],
+        'customGroups': const [],
+      }),
+    });
+    final repository = await VaultRepository.open();
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          vaultRepositoryProvider.overrideWithValue(repository),
+        ],
+        child: const MaterialApp(home: SnippetsScreen()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Disk usage'), findsOneWidget);
+    await tester.tap(find.byKey(const ValueKey('snippet-actions-snippet-1')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.byKey(const ValueKey('delete-snippet-snippet-1')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('删除命令片段？'), findsOneWidget);
+    expect(
+      find.text('将删除“Disk usage”，此操作可通过云同步传播到其他设备。'),
+      findsOneWidget,
+    );
+    await tester.tap(find.byKey(const ValueKey('confirm-delete-snippet')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Disk usage'), findsNothing);
+    expect(find.text('还没有命令片段'), findsOneWidget);
+    expect((await repository.loadVault()).snippets, isEmpty);
+  });
+}


### PR DESCRIPTION
## 主要改动

- Android 使用前台服务、CPU WakeLock 和 Wi-Fi Lock 保持 SSH 会话，并在断线重连期间继续运行
- iOS 使用静音 AVAudioEngine 获得持续后台执行时间，支持音频中断、路由变化和媒体服务重置后恢复
- 画中画持续刷新 sample-buffer 帧，增强静止终端场景下的稳定性
- 后台每 8 秒探测链路，断线后以 1～30 秒退避自动重连
- 片段页面增加删除菜单、二次确认与持久化测试

## 验证

- flutter analyze --no-pub
- flutter test --no-pub（60 项通过）
- flutter build apk --release --no-pub（成功生成 64.6 MB APK）
- iOS 交由 macOS CI 完成原生编译验证