### PR TITLE
fix: sync vault metadata safely after host changes

### DIFF
--- a/lib/application/vault_controller.dart
+++ b/lib/application/vault_controller.dart
@@ -73,21 +73,69 @@ class VaultController extends StateNotifier<VaultState> {
     });
     final hosts = [...vault.hosts];
     final index = hosts.indexWhere((value) => value.id == stamped.id);
+    final previousGroup = index == -1 ? null : _normalizedGroup(hosts[index]);
     if (index == -1) {
       hosts.add(stamped);
     } else {
       hosts[index] = stamped;
     }
-    await replace(vault.copyWith(hosts: hosts));
+    await replace(
+      vault.copyWith(
+        hosts: hosts,
+        customGroups: _updatedGroups(
+          vault.customGroups,
+          hosts,
+          previousGroup: previousGroup,
+          currentGroup: _normalizedGroup(stamped),
+        ),
+      ),
+    );
   }
 
   Future<void> deleteHost(String id) async {
     final vault = await ready();
+    final removedHost = vault.hosts.cast<HostProfile?>().firstWhere(
+          (value) => value?.id == id,
+          orElse: () => null,
+        );
+    final hosts = vault.hosts.where((value) => value.id != id).toList();
     await replace(
       vault.copyWith(
-        hosts: vault.hosts.where((value) => value.id != id).toList(),
+        hosts: hosts,
+        customGroups: _updatedGroups(
+          vault.customGroups,
+          hosts,
+          previousGroup:
+              removedHost == null ? null : _normalizedGroup(removedHost),
+        ),
       ),
     );
+  }
+
+  String? _normalizedGroup(HostProfile host) {
+    final value = host.group?.trim();
+    return value == null || value.isEmpty ? null : value;
+  }
+
+  List<String> _updatedGroups(
+    List<String> current,
+    List<HostProfile> hosts, {
+    String? previousGroup,
+    String? currentGroup,
+  }) {
+    final groups = current
+        .map((value) => value.trim())
+        .where((value) => value.isNotEmpty)
+        .toList(growable: true);
+    if (currentGroup != null && !groups.contains(currentGroup)) {
+      groups.add(currentGroup);
+    }
+    if (previousGroup != null &&
+        previousGroup != currentGroup &&
+        !hosts.any((host) => _normalizedGroup(host) == previousGroup)) {
+      groups.removeWhere((group) => group == previousGroup);
+    }
+    return groups.toSet().toList(growable: false);
   }
 
   Future<void> upsertSnippet(CommandSnippet snippet) async {

--- a/lib/infrastructure/sync/vault_merge_service.dart
+++ b/lib/infrastructure/sync/vault_merge_service.dart
@@ -98,11 +98,74 @@ VaultData mergeVaults({
     customGroups: groups,
     proxyProfiles: proxies,
     extras: {
-      ...remote.extras,
-      ...local.extras,
+      ..._mergeOpaqueExtras(local.extras, remote.extras),
       VaultSyncState.storageKey: state.toJson(),
     },
   );
+}
+
+/// Desktop Netcatty owns every opaque payload field except the mobile sync
+/// sidecar and the host-key trust records maintained by this client. A mobile
+/// vault can contain an older cached copy of `settings` (including AI
+/// providers), notes, plugin sidecars, or other desktop-only data. Letting that
+/// cache win would roll the desktop back whenever an unrelated mobile entity
+/// changed, so the freshly downloaded snapshot is authoritative here.
+Map<String, dynamic> _mergeOpaqueExtras(
+  Map<String, dynamic> local,
+  Map<String, dynamic> remote,
+) {
+  final result = Map<String, dynamic>.from(remote);
+
+  // Preserve current and future mobile-private sidecars without allowing them
+  // to overwrite a newer copy already present in the downloaded vault.
+  for (final entry in local.entries) {
+    if (entry.key.startsWith('_netcattyMobile')) {
+      result.putIfAbsent(entry.key, () => entry.value);
+    }
+  }
+
+  final knownHosts = _mergeKnownHosts(
+    remote['knownHosts'],
+    local['knownHosts'],
+  );
+  if (knownHosts == null) {
+    result.remove('knownHosts');
+  } else {
+    result['knownHosts'] = knownHosts;
+  }
+  return result;
+}
+
+List<dynamic>? _mergeKnownHosts(Object? remote, Object? local) {
+  if (remote is! List && local is! List) return null;
+  final merged = <String, dynamic>{};
+
+  void addAll(Object? value, String source) {
+    if (value is! List) return;
+    for (var index = 0; index < value.length; index++) {
+      final item = value[index];
+      merged[_knownHostKey(item, source, index)] = item;
+    }
+  }
+
+  addAll(remote, 'remote');
+  // A fingerprint accepted on this phone is device-local state and must not be
+  // discarded merely because desktop cloud snapshots omit knownHosts.
+  addAll(local, 'local');
+  return merged.values.toList(growable: false);
+}
+
+String _knownHostKey(Object? value, String source, int index) {
+  if (value is Map) {
+    final hostname = value['hostname']?.toString().trim() ?? '';
+    if (hostname.isNotEmpty) {
+      final port = (value['port'] as num?)?.toInt() ?? 22;
+      return '$hostname:$port';
+    }
+    final id = value['id']?.toString().trim() ?? '';
+    if (id.isNotEmpty) return 'id:$id';
+  }
+  return '$source:$index';
 }
 
 List<T> _mergeEntities<T>({

--- a/lib/presentation/screens/vault_screen.dart
+++ b/lib/presentation/screens/vault_screen.dart
@@ -28,13 +28,23 @@ class _VaultScreenState extends ConsumerState<VaultScreen> {
     final settings = ref.watch(settingsControllerProvider);
     final viewMode = settings.serverViewMode;
     final vault = state.data;
+    final groups = vault?.customGroups ?? const <String>[];
+    final selectedGroup = groups.contains(_group) ? _group : null;
+    if (_group != null && selectedGroup == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted && _group != null && !groups.contains(_group)) {
+          setState(() => _group = null);
+        }
+      });
+    }
     final hosts = (vault?.hosts ?? const <HostProfile>[]).where((host) {
       final query = _search.text.toLowerCase();
       final matchesQuery = query.isEmpty ||
           host.label.toLowerCase().contains(query) ||
           host.hostname.toLowerCase().contains(query) ||
           host.tags.any((tag) => tag.toLowerCase().contains(query));
-      return matchesQuery && (_group == null || host.group == _group);
+      return matchesQuery &&
+          (selectedGroup == null || host.group == selectedGroup);
     }).toList()
       ..sort((a, b) {
         if (a.pinned != b.pinned) return a.pinned ? -1 : 1;
@@ -112,7 +122,7 @@ class _VaultScreenState extends ConsumerState<VaultScreen> {
               ),
             ),
           ),
-          if ((vault?.customGroups.isNotEmpty ?? false))
+          if (groups.isNotEmpty)
             SizedBox(
               height: 48,
               child: ListView(
@@ -124,14 +134,14 @@ class _VaultScreenState extends ConsumerState<VaultScreen> {
                 children: [
                   ChoiceChip(
                     label: const LText('全部'),
-                    selected: _group == null,
+                    selected: selectedGroup == null,
                     onSelected: (_) => setState(() => _group = null),
                   ),
                   const SizedBox(width: 8),
-                  for (final group in vault!.customGroups) ...[
+                  for (final group in groups) ...[
                     ChoiceChip(
                       label: LText(group),
-                      selected: _group == group,
+                      selected: selectedGroup == group,
                       onSelected: (_) => setState(() => _group = group),
                     ),
                     const SizedBox(width: 8),

--- a/lib/presentation/widgets/host_editor.dart
+++ b/lib/presentation/widgets/host_editor.dart
@@ -540,7 +540,10 @@ class _HostEditorState extends ConsumerState<HostEditor> {
 
   Future<void> _delete() async {
     FocusManager.instance.primaryFocus?.unfocus();
-    if (await widget.onDelete!() && mounted) Navigator.pop(context);
+    final navigator = Navigator.of(context);
+    if (await widget.onDelete!() && navigator.canPop()) {
+      navigator.pop();
+    }
   }
 
   void _save() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: netcatty_mobile
 description: Netcatty mobile SSH, SFTP and cloud-sync client for Android and iOS.
 publish_to: none
-version: 1.3.8+17
+version: 1.3.9+18
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/test/host_editor_layout_test.dart
+++ b/test/host_editor_layout_test.dart
@@ -114,4 +114,52 @@ void main() {
 
     expect(deleted, isTrue);
   });
+
+  testWidgets('successful host deletion closes the editor sheet',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final repository = await VaultRepository.open();
+    final host = HostProfile.create(
+      id: 'host-1',
+      label: 'Example',
+      hostname: 'example.com',
+      username: 'root',
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [vaultRepositoryProvider.overrideWithValue(repository)],
+        child: MaterialApp(
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: FilledButton(
+                onPressed: () => showModalBottomSheet<void>(
+                  context: context,
+                  isScrollControlled: true,
+                  builder: (_) => HostEditor(
+                    host: host,
+                    onDelete: () async => true,
+                  ),
+                ),
+                child: const Text('Edit'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Edit'));
+    await tester.pumpAndSettle();
+    await tester.scrollUntilVisible(
+      find.byKey(const ValueKey('delete-host-from-editor')),
+      500,
+      scrollable: find.byType(Scrollable).first,
+    );
+    await tester.tap(find.byKey(const ValueKey('delete-host-from-editor')));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HostEditor), findsNothing);
+    expect(find.text('Edit'), findsOneWidget);
+  });
 }

--- a/test/vault_loading_test.dart
+++ b/test/vault_loading_test.dart
@@ -97,4 +97,77 @@ void main() {
     expect(controller.state.data?.snippets.single.id, 'snippet-fast');
     expect(repository.loadVaultPreview()?.snippets.single.id, 'snippet-fast');
   });
+
+  test('host edits keep custom group tabs synchronized', () async {
+    const secureStorageChannel =
+        MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(secureStorageChannel, (_) async => null);
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(secureStorageChannel, null);
+    });
+    SharedPreferences.setMockInitialValues({
+      'netcatty_mobile_vault_v1': jsonEncode({
+        'hosts': [
+          {
+            'id': 'host-1',
+            'label': 'Server',
+            'hostname': '192.0.2.10',
+            'username': 'root',
+            'group': 'Old group',
+          },
+        ],
+        'keys': const [],
+        'snippets': const [],
+        'customGroups': ['Old group'],
+      }),
+    });
+    final repository = await VaultRepository.open();
+    final controller = VaultController(repository);
+    await controller.load();
+
+    final edited = controller.state.data!.hosts.single.copyWith(
+      group: 'New group',
+    );
+    await controller.upsertHost(edited);
+
+    expect(controller.state.data!.customGroups, ['New group']);
+    expect(repository.loadVaultPreview()!.customGroups, ['New group']);
+  });
+
+  test('deleting the last host removes its unused group tab', () async {
+    const secureStorageChannel =
+        MethodChannel('plugins.it_nomads.com/flutter_secure_storage');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(secureStorageChannel, (_) async => null);
+    addTearDown(() {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(secureStorageChannel, null);
+    });
+    SharedPreferences.setMockInitialValues({
+      'netcatty_mobile_vault_v1': jsonEncode({
+        'hosts': [
+          {
+            'id': 'host-1',
+            'label': 'Server',
+            'hostname': '192.0.2.10',
+            'username': 'root',
+            'group': 'Temporary',
+          },
+        ],
+        'keys': const [],
+        'snippets': const [],
+        'customGroups': ['Temporary'],
+      }),
+    });
+    final repository = await VaultRepository.open();
+    final controller = VaultController(repository);
+    await controller.load();
+
+    await controller.deleteHost('host-1');
+
+    expect(controller.state.data!.hosts, isEmpty);
+    expect(controller.state.data!.customGroups, isEmpty);
+  });
 }

--- a/test/vault_merge_service_test.dart
+++ b/test/vault_merge_service_test.dart
@@ -74,6 +74,173 @@ void main() {
     final merged = mergeVaults(local: left, remote: right);
 
     expect(
-        merged.hosts.map((value) => value.id), containsAll(['left', 'right']));
+      merged.hosts.map((value) => value.id),
+      containsAll(['left', 'right']),
+    );
+  });
+
+  test('cloud desktop settings replace a stale mobile cached snapshot', () {
+    final local = VaultData.fromJson({
+      'hosts': const [],
+      'keys': const [],
+      'snippets': const [],
+      'customGroups': const [],
+      'settings': {
+        'theme': 'light',
+        'ai': {
+          'providers': [
+            {'id': 'stale-provider', 'name': 'Old API Agent'},
+          ],
+          'defaultAgentId': 'codex',
+        },
+      },
+    });
+    final remote = VaultData.fromJson({
+      'hosts': const [],
+      'keys': const [],
+      'snippets': const [],
+      'customGroups': const [],
+      'settings': {
+        'theme': 'dark',
+        'ai': {
+          'providers': [
+            {'id': 'desktop-api', 'name': 'Desktop API Agent'},
+          ],
+          'activeProviderId': 'desktop-api',
+          'defaultAgentId': 'catty',
+        },
+      },
+    });
+
+    final merged = mergeVaults(local: local, remote: remote);
+
+    expect(merged.extras['settings'], remote.extras['settings']);
+    final ai = (merged.extras['settings'] as Map)['ai'] as Map;
+    expect((ai['providers'] as List).single['id'], 'desktop-api');
+    expect(ai['defaultAgentId'], 'catty');
+  });
+
+  test('removed desktop settings are not resurrected from mobile cache', () {
+    final local = VaultData.fromJson({
+      'hosts': const [],
+      'keys': const [],
+      'snippets': const [],
+      'customGroups': const [],
+      'settings': {
+        'ai': {
+          'providers': [
+            {'id': 'deleted-provider'},
+          ],
+        },
+      },
+      'pluginSidecars': {
+        'version': 1,
+        'entries': [
+          {'pluginId': 'stale-plugin'},
+        ],
+      },
+    });
+    final remote = VaultData.empty();
+
+    final merged = mergeVaults(local: local, remote: remote);
+
+    expect(merged.extras.containsKey('settings'), isFalse);
+    expect(merged.extras.containsKey('pluginSidecars'), isFalse);
+  });
+
+  test('desktop-only payload fields always follow the downloaded snapshot', () {
+    final local = VaultData.fromJson({
+      'hosts': const [],
+      'keys': const [],
+      'snippets': const [],
+      'customGroups': const [],
+      'notes': [
+        {'id': 'old-note'},
+      ],
+      'portForwardingRules': [
+        {'id': 'old-forward'},
+      ],
+      'groupConfigs': [
+        {'id': 'old-group'},
+      ],
+      'syncMeta': {'writer': 'old-mobile-cache'},
+    });
+    final remote = VaultData.fromJson({
+      'hosts': const [],
+      'keys': const [],
+      'snippets': const [],
+      'customGroups': const [],
+      'notes': [
+        {'id': 'new-note'},
+      ],
+      'portForwardingRules': [
+        {'id': 'new-forward'},
+      ],
+      'groupConfigs': [
+        {'id': 'new-group'},
+      ],
+      'syncMeta': {'writer': 'desktop'},
+    });
+
+    final merged = mergeVaults(local: local, remote: remote);
+
+    expect((merged.extras['notes'] as List).single['id'], 'new-note');
+    expect(
+      (merged.extras['portForwardingRules'] as List).single['id'],
+      'new-forward',
+    );
+    expect(
+      (merged.extras['groupConfigs'] as List).single['id'],
+      'new-group',
+    );
+    expect((merged.extras['syncMeta'] as Map)['writer'], 'desktop');
+  });
+
+  test('mobile host-key trust and private sync metadata stay intact', () {
+    final local = VaultData.fromJson({
+      'hosts': const [],
+      'keys': const [],
+      'snippets': const [],
+      'customGroups': const [],
+      'knownHosts': [
+        {
+          'hostname': 'server.example.com',
+          'port': 22,
+          'fingerprint': 'mobile-new',
+        },
+      ],
+      '_netcattyMobileFuture': {'enabled': true},
+    });
+    final remote = VaultData.fromJson({
+      'hosts': const [],
+      'keys': const [],
+      'snippets': const [],
+      'customGroups': const [],
+      'knownHosts': [
+        {
+          'hostname': 'server.example.com',
+          'port': 22,
+          'fingerprint': 'remote-old',
+        },
+        {
+          'hostname': 'other.example.com',
+          'port': 2222,
+          'fingerprint': 'remote-other',
+        },
+      ],
+    });
+
+    final merged = mergeVaults(local: local, remote: remote);
+    final knownHosts = (merged.extras['knownHosts'] as List).cast<Map>();
+
+    expect(knownHosts, hasLength(2));
+    expect(
+      knownHosts.singleWhere(
+        (entry) => entry['hostname'] == 'server.example.com',
+      )['fingerprint'],
+      'mobile-new',
+    );
+    expect(merged.extras['_netcattyMobileFuture'], {'enabled': true});
+    expect(merged.extras[VaultSyncState.storageKey], isA<Map>());
   });
 }


### PR DESCRIPTION
修复三类保险库问题：一、编辑服务器分组后顶部标签立即同步，未使用旧分组会移除，失效筛选回到全部；二、删除服务器成功后编辑详情页自动关闭；三、手机拉取并合并时不再用旧缓存覆盖桌面 settings.ai、主题、终端设置、备注、端口转发、分组配置和插件 Sidecar，手机 SSH 指纹记录仍单独保留。新增控制器、Widget 与桌面同步兼容回归测试。验证：Dart analyze 通过，Flutter 全量 90 项测试通过，本地 Android Release APK 编译通过。