### PR TITLE
增强 SFTP 文件操作并修复同步删除复活

### DIFF
--- a/lib/infrastructure/ssh/sftp_service.dart
+++ b/lib/infrastructure/ssh/sftp_service.dart
@@ -15,6 +15,7 @@ class RemoteEntry {
     required this.isDirectory,
     required this.size,
     this.modifiedAt,
+    this.unixMode,
   });
 
   final String name;
@@ -22,7 +23,20 @@ class RemoteEntry {
   final bool isDirectory;
   final int size;
   final DateTime? modifiedAt;
+  final int? unixMode;
 }
+
+int? parseUnixPermissions(String value) {
+  final normalized = value.trim();
+  if (!RegExp(r'^[0-7]{3,4}$').hasMatch(normalized)) return null;
+  return int.parse(normalized, radix: 8);
+}
+
+String? formatUnixPermissions(int? mode) =>
+    mode == null ? null : (mode & 0xfff).toRadixString(8).padLeft(3, '0');
+
+String quoteSftpTerminalPath(String path) =>
+    "'${path.replaceAll("'", "'\\''")}'";
 
 typedef TransferProgressCallback = void Function(int transferredBytes);
 
@@ -49,6 +63,7 @@ abstract class FileTransferService {
   String get displayName;
   String get rootPath;
   bool get isLocal;
+  bool get supportsUnixPermissions => false;
 
   String displayPath(String path);
   String joinPath(String path, String name);
@@ -71,6 +86,8 @@ abstract class FileTransferService {
   Future<void> ensureDirectory(String path);
   Future<void> rename(String from, String to);
   Future<void> delete(RemoteEntry entry);
+  Future<void> setPermissions(String path, int mode) =>
+      Future<void>.error(UnsupportedError('当前文件来源不支持修改权限'));
 
   Future<Uint8List> readBytes(String path) async {
     final builder = BytesBuilder(copy: false);
@@ -111,6 +128,8 @@ class SftpService extends FileTransferService {
   String get rootPath => '/';
   @override
   bool get isLocal => false;
+  @override
+  bool get supportsUnixPermissions => true;
 
   Future<SftpClient> get _sftp async {
     final ssh = session.sshClient;
@@ -147,6 +166,7 @@ class SftpService extends FileTransferService {
         path: fullPath,
         isDirectory: item.attr.mode?.type == SftpFileType.directory,
         size: item.attr.size ?? 0,
+        unixMode: item.attr.mode?.value,
         modifiedAt: modified == null
             ? null
             : DateTime.fromMillisecondsSinceEpoch(modified * 1000),
@@ -236,6 +256,17 @@ class SftpService extends FileTransferService {
   @override
   Future<void> rename(String from, String to) async =>
       (await _sftp).rename(from, to);
+
+  @override
+  Future<void> setPermissions(String path, int mode) async {
+    if (mode < 0 || mode > 0xfff) {
+      throw StateError('Unix 权限必须在 0000 到 7777 之间');
+    }
+    await (await _sftp).setStat(
+      path,
+      SftpFileAttrs(mode: SftpFileMode.value(mode)),
+    );
+  }
 
   /// Retained for callers that copy within this SSH session.
   Future<int> copyEntry(RemoteEntry entry, String targetDirectory) =>

--- a/lib/infrastructure/sync/vault_merge_service.dart
+++ b/lib/infrastructure/sync/vault_merge_service.dart
@@ -201,7 +201,23 @@ List<T> _mergeEntities<T>({
         fallback: remoteFallbackTimestamp,
       ),
     );
-    final deletion = mergedTombstones[kind]?[id] ?? 0;
+    var deletion = mergedTombstones[kind]?[id] ?? 0;
+    // Desktop Netcatty preserves the mobile revision sidecar but does not
+    // create mobile tombstones. A revision without its previously materialized
+    // entity therefore means the entity was deleted on desktop. Record that
+    // deletion before merging so the cached mobile copy is not uploaded again.
+    final remotePreviouslyKnewEntity = remoteItem == null &&
+        localItem != null &&
+        (remoteState.revisions[kind]?.containsKey(id) ?? false);
+    if (remotePreviouslyKnewEntity) {
+      final inferredDeletion = remoteFallbackTimestamp > 0
+          ? remoteFallbackTimestamp
+          : remoteRevision;
+      if (inferredDeletion > deletion) {
+        deletion = inferredDeletion;
+        mergedTombstones[kind]?[id] = inferredDeletion;
+      }
+    }
     final winningRevision =
         localRevision > remoteRevision ? localRevision : remoteRevision;
     if (deletion >= winningRevision && deletion > 0) {
@@ -244,7 +260,20 @@ List<String> _mergeGroups(
     );
     final winningRevision =
         localRevision > remoteRevision ? localRevision : remoteRevision;
-    final deletion = tombstones[VaultSyncState.groups]?[group] ?? 0;
+    var deletion = tombstones[VaultSyncState.groups]?[group] ?? 0;
+    final remotePreviouslyKnewGroup = localSet.contains(group) &&
+        !remoteSet.contains(group) &&
+        (remoteState.revisions[VaultSyncState.groups]?.containsKey(group) ??
+            false);
+    if (remotePreviouslyKnewGroup) {
+      final inferredDeletion = remoteFallbackTimestamp > 0
+          ? remoteFallbackTimestamp
+          : remoteRevision;
+      if (inferredDeletion > deletion) {
+        deletion = inferredDeletion;
+        tombstones[VaultSyncState.groups]?[group] = inferredDeletion;
+      }
+    }
     if (deletion >= winningRevision && deletion > 0) {
       revisions[VaultSyncState.groups]?.remove(group);
       continue;

--- a/lib/presentation/localization/translations_en.dart
+++ b/lib/presentation/localization/translations_en.dart
@@ -281,6 +281,25 @@ const englishTranslations = <String, String>{
   '文件操作': 'File actions',
   '传输到另一栏': 'Transfer to the other pane',
   '下载 / 分享': 'Download / share',
+  '复制文件路径': 'Copy file path',
+  '文件路径已复制': 'File path copied',
+  '修改文件权限': 'Change file permissions',
+  '当前文件来源不支持修改权限':
+      'The current file source does not support permission changes',
+  'Unix 权限必须在 0000 到 7777 之间': 'Unix permissions must be between 0000 and 7777',
+  '在终端中打开当前目录': 'Open current folder in terminal',
+  'Unix 权限': 'Unix permissions',
+  '例如 644 或 0755': 'For example, 644 or 0755',
+  '依次表示所有者、用户组和其他用户的读写执行权限':
+      'Read, write, and execute permissions for owner, group, and others',
+  '请输入 3 或 4 位八进制权限（0-7）': 'Enter a 3- or 4-digit octal permission (0-7)',
+  '应用': 'Apply',
+  r'修改 ${entry.name} 的权限': r'Change permissions for ${entry.name}',
+  r'权限已修改为 ${formatUnixPermissions(mode)}':
+      r'Permissions changed to ${formatUnixPermissions(mode)}',
+  '无法打开终端：对应的 SSH 会话已断开':
+      'Unable to open terminal: the SSH session is disconnected',
+  r'无法在终端中打开目录：$error': r'Unable to open the folder in terminal: $error',
   '重命名': 'Rename',
   '新名称': 'New name',
   '取消传输': 'Cancel transfer',

--- a/lib/presentation/screens/sftp_screen.dart
+++ b/lib/presentation/screens/sftp_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:netcatty_mobile/presentation/localization/localized_widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:path_provider/path_provider.dart';
@@ -163,6 +163,9 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
                           sources: sources,
                           onSourceChanged: (id) => _changeSource(true, id),
                           onPhoneMountChanged: _phoneMountChanged,
+                          onOpenInTerminal: left.isLocal
+                              ? null
+                              : (path) => _openInTerminal(left, path),
                           onCopyToOther: _dualPane
                               ? (entry) =>
                                   _copy(entry, _leftKey, _rightKey, '右侧')
@@ -186,6 +189,9 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
                             sources: sources,
                             onSourceChanged: (id) => _changeSource(false, id),
                             onPhoneMountChanged: _phoneMountChanged,
+                            onOpenInTerminal: right.isLocal
+                                ? null
+                                : (path) => _openInTerminal(right, path),
                             onCopyToOther: (entry) =>
                                 _copy(entry, _rightKey, _leftKey, '左侧'),
                           ),
@@ -255,6 +261,30 @@ class _SftpScreenState extends ConsumerState<SftpScreen> {
     setState(() {});
     _leftKey.currentState?.resetAfterPhoneMount();
     _rightKey.currentState?.resetAfterPhoneMount();
+  }
+
+  void _openInTerminal(FileTransferService service, String path) {
+    if (service is! SftpService) return;
+    final controller = ref.read(sessionControllerProvider.notifier);
+    final sessions = ref.read(sessionControllerProvider).sessions;
+    final index = sessions.indexWhere(
+      (session) => session.id == service.session.id,
+    );
+    if (index < 0 || !service.session.connected) {
+      _message('无法打开终端：对应的 SSH 会话已断开');
+      return;
+    }
+    try {
+      controller.activate(index);
+      controller.sendToSession(
+        service.session.id,
+        'cd ${quoteSftpTerminalPath(path)}',
+        enter: true,
+      );
+      ref.read(homeTabProvider.notifier).state = 1;
+    } catch (error) {
+      _message('无法在终端中打开目录：$error');
+    }
   }
 
   Future<void> _copy(

--- a/lib/presentation/screens/sftp_screen_pane.dart
+++ b/lib/presentation/screens/sftp_screen_pane.dart
@@ -9,6 +9,7 @@ class _SftpPane extends StatefulWidget {
     required this.onSourceChanged,
     required this.onPhoneMountChanged,
     this.onCopyToOther,
+    this.onOpenInTerminal,
   });
 
   final String label;
@@ -17,6 +18,7 @@ class _SftpPane extends StatefulWidget {
   final ValueChanged<String> onSourceChanged;
   final VoidCallback onPhoneMountChanged;
   final ValueChanged<RemoteEntry>? onCopyToOther;
+  final ValueChanged<String>? onOpenInTerminal;
 
   @override
   State<_SftpPane> createState() => _SftpPaneState();
@@ -164,6 +166,16 @@ class _SftpPaneState extends State<_SftpPane> {
                         _loading || !localReady ? null : refresh,
                       ),
                     ),
+                    if (widget.onOpenInTerminal != null)
+                      Expanded(
+                        child: _toolbar(
+                          Icons.terminal_outlined,
+                          '在终端中打开当前目录',
+                          _loading
+                              ? null
+                              : () => widget.onOpenInTerminal!(path),
+                        ),
+                      ),
                     if (mountable != null && !mountable.usesAppDocuments)
                       Expanded(
                         child: _toolbar(
@@ -287,6 +299,21 @@ class _SftpPaneState extends State<_SftpPane> {
                 child: ListTile(
                   leading: Icon(Icons.ios_share_outlined),
                   title: LText('下载 / 分享'),
+                ),
+              ),
+            const PopupMenuItem(
+              value: 'copy-path',
+              child: ListTile(
+                leading: Icon(Icons.content_copy_outlined),
+                title: LText('复制文件路径'),
+              ),
+            ),
+            if (service.supportsUnixPermissions)
+              const PopupMenuItem(
+                value: 'permissions',
+                child: ListTile(
+                  leading: Icon(Icons.admin_panel_settings_outlined),
+                  title: LText('修改文件权限'),
                 ),
               ),
             const PopupMenuItem(
@@ -520,8 +547,18 @@ class _SftpPaneState extends State<_SftpPane> {
       return;
     }
     if (action == 'share') return _share(entry);
+    if (action == 'copy-path') {
+      await Clipboard.setData(ClipboardData(text: entry.path));
+      _message('文件路径已复制');
+      return;
+    }
     try {
-      if (action == 'rename') {
+      if (action == 'permissions') {
+        final mode = await _askPermissions(entry);
+        if (mode == null) return;
+        await service.setPermissions(entry.path, mode);
+        _message('权限已修改为 ${formatUnixPermissions(mode)}');
+      } else if (action == 'rename') {
         final name = await _ask('重命名', '新名称', entry.name);
         if (name != null && name.isNotEmpty && name != entry.name) {
           await service.rename(entry.path, service.joinPath(path, name));
@@ -573,6 +610,54 @@ class _SftpPaneState extends State<_SftpPane> {
           FilledButton(
             onPressed: () => Navigator.pop(context, controller.text.trim()),
             child: const LText('确定'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<int?> _askPermissions(RemoteEntry entry) {
+    final formKey = GlobalKey<FormState>();
+    final controller = TextEditingController(
+      text: formatUnixPermissions(entry.unixMode) ??
+          (entry.isDirectory ? '755' : '644'),
+    );
+    return showDialog<int>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: LText('修改 ${entry.name} 的权限'),
+        content: Form(
+          key: formKey,
+          child: TextFormField(
+            key: const ValueKey('sftp-permissions-input'),
+            controller: controller,
+            autofocus: true,
+            keyboardType: TextInputType.number,
+            maxLength: 4,
+            decoration: LInputDecoration(
+              labelText: 'Unix 权限',
+              hintText: '例如 644 或 0755',
+              helperText: '依次表示所有者、用户组和其他用户的读写执行权限',
+            ),
+            validator: (value) => parseUnixPermissions(value ?? '') == null
+                ? localized('请输入 3 或 4 位八进制权限（0-7）')
+                : null,
+          ),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const LText('取消'),
+          ),
+          FilledButton(
+            onPressed: () {
+              if (formKey.currentState?.validate() != true) return;
+              Navigator.pop(
+                context,
+                parseUnixPermissions(controller.text),
+              );
+            },
+            child: const LText('应用'),
           ),
         ],
       ),

--- a/test/cloud_sync_service_test.dart
+++ b/test/cloud_sync_service_test.dart
@@ -7,6 +7,7 @@ import 'package:http/testing.dart';
 import 'package:netcatty_mobile/domain/models/host.dart';
 import 'package:netcatty_mobile/domain/models/settings.dart';
 import 'package:netcatty_mobile/domain/models/vault.dart';
+import 'package:netcatty_mobile/domain/models/vault_sync_state.dart';
 import 'package:netcatty_mobile/infrastructure/storage/vault_repository.dart';
 import 'package:netcatty_mobile/infrastructure/sync/cloud_sync_service.dart';
 import 'package:netcatty_mobile/infrastructure/sync/netcatty_crypto.dart';
@@ -192,6 +193,104 @@ void main() {
     expect(versions.localVersion, 9);
     expect(versions.cloudVersion, 8);
     expect(versions.hasLocalChanges, isTrue);
+  });
+
+  test('desktop host and key deletions are not uploaded back from mobile',
+      () async {
+    SharedPreferences.setMockInitialValues({});
+    final repository = await VaultRepository.open();
+    await repository.saveSyncConnection(const SyncConnection(
+      type: SyncProviderType.githubGist,
+      endpoint: '',
+      secret: 'token',
+      resourceId: 'gist-desktop-deletion',
+    ));
+    await repository.saveMasterPassword('sync-password');
+    final local = stampLocalVaultChanges(
+      VaultData.empty(),
+      VaultData.empty().copyWith(
+        hosts: [
+          HostProfile.create(
+            id: 'deleted-host',
+            label: 'Deleted on desktop',
+            hostname: 'deleted.example.com',
+            username: 'root',
+          ),
+        ],
+        keys: [
+          SshKeyProfile({
+            'id': 'deleted-key',
+            'label': 'Deleted key',
+            'privateKey': 'secret',
+          }),
+        ],
+      ),
+      timestamp: 100,
+    );
+    final desktopSnapshot = local.copyWith(hosts: [], keys: []);
+    final remoteFile = await NetcattyCrypto.encrypt(
+      vault: desktopSnapshot,
+      password: 'sync-password',
+      deviceId: 'desktop-device',
+      deviceName: 'Desktop',
+      appVersion: '1.4.0',
+      previousVersion: 4,
+    );
+    final gistResponse = jsonEncode({
+      'files': {
+        'netcatty-vault.json': {
+          'content': jsonEncode(remoteFile.toJson()),
+          'truncated': false,
+        },
+      },
+    });
+    VaultData? uploadedVault;
+    final client = MockClient((request) async {
+      if (request.method == 'GET') {
+        return http.Response(
+          gistResponse,
+          200,
+          headers: {'etag': '"desktop-deletion"'},
+        );
+      }
+      if (request.method == 'PATCH') {
+        final body = jsonDecode(request.body) as Map<String, dynamic>;
+        final files = body['files'] as Map<String, dynamic>;
+        final encrypted = SyncedVaultFile.fromJson(
+          jsonDecode(
+            (files['netcatty-vault.json'] as Map<String, dynamic>)['content']
+                as String,
+          ) as Map<String, dynamic>,
+        );
+        uploadedVault = await NetcattyCrypto.decrypt(
+          encrypted,
+          'sync-password',
+        );
+        return http.Response('{}', 200);
+      }
+      fail('Unexpected ${request.method} request to ${request.url}');
+    });
+
+    final result = await CloudSyncService(
+      repository,
+      client: client,
+      deviceId: 'mobile-device',
+      appVersion: '1.4.0',
+    ).pullAndMerge(local);
+
+    expect(result.vault.hosts, isEmpty);
+    expect(result.vault.keys, isEmpty);
+    expect(uploadedVault?.hosts, isEmpty);
+    expect(uploadedVault?.keys, isEmpty);
+    final uploadedState = VaultSyncState.fromVault(uploadedVault!);
+    expect(
+      uploadedState.deletedAt(VaultSyncState.hosts, 'deleted-host'),
+      greaterThan(100),
+    );
+    expect(
+      uploadedState.deletedAt(VaultSyncState.keys, 'deleted-key'),
+      greaterThan(100),
+    );
   });
 
   test('WebDAV upload uses the desktop temp PUT and MOVE replacement flow',

--- a/test/sftp_terminal_usability_test.dart
+++ b/test/sftp_terminal_usability_test.dart
@@ -136,6 +136,25 @@ void main() {
     expect(identical(normalized, chunk), isTrue);
   });
 
+  test('SFTP Unix permissions parse, format, and reject invalid values', () {
+    expect(parseUnixPermissions('644'), 0x1a4);
+    expect(parseUnixPermissions('0755'), 0x1ed);
+    expect(parseUnixPermissions(' 700 '), 0x1c0);
+    expect(parseUnixPermissions('888'), isNull);
+    expect(parseUnixPermissions('64'), isNull);
+    expect(parseUnixPermissions('07555'), isNull);
+    expect(formatUnixPermissions(0x81a4), '644');
+    expect(formatUnixPermissions(0x1ed), '755');
+  });
+
+  test('SFTP terminal directory path is safely quoted for POSIX shells', () {
+    expect(quoteSftpTerminalPath('/srv/My Files'), "'/srv/My Files'");
+    expect(
+      quoteSftpTerminalPath("/srv/user's files"),
+      "'/srv/user'\\''s files'",
+    );
+  });
+
   testWidgets(
     'SFTP uses a transparent title bar and switches between two and one pane',
     (tester) async {

--- a/test/vault_merge_service_test.dart
+++ b/test/vault_merge_service_test.dart
@@ -59,6 +59,82 @@ void main() {
     );
   });
 
+  test('desktop deletion inferred from a missing entity with preserved clocks',
+      () {
+    final original = stampLocalVaultChanges(
+      VaultData.empty(),
+      VaultData.empty().copyWith(
+        hosts: [host('desktop-deleted-host', 'Delete host on desktop')],
+        keys: [
+          SshKeyProfile({
+            'id': 'desktop-deleted-key',
+            'label': 'Delete key on desktop',
+            'privateKey': 'secret',
+          }),
+        ],
+        customGroups: ['Desktop deleted group'],
+      ),
+      timestamp: 100,
+    );
+    final desktopSnapshot = original.copyWith(
+      hosts: [],
+      keys: [],
+      customGroups: [],
+    );
+
+    final merged = mergeVaults(
+      local: original,
+      remote: desktopSnapshot,
+      remoteFallbackTimestamp: 300,
+    );
+    final state = VaultSyncState.fromVault(merged);
+
+    expect(merged.hosts, isEmpty);
+    expect(merged.keys, isEmpty);
+    expect(merged.customGroups, isEmpty);
+    expect(
+      state.deletedAt(VaultSyncState.hosts, 'desktop-deleted-host'),
+      300,
+    );
+    expect(
+      state.deletedAt(VaultSyncState.keys, 'desktop-deleted-key'),
+      300,
+    );
+    expect(
+      state.deletedAt(VaultSyncState.groups, 'Desktop deleted group'),
+      300,
+    );
+  });
+
+  test('a newer mobile edit still wins over an older desktop deletion', () {
+    final original = stampLocalVaultChanges(
+      VaultData.empty(),
+      VaultData.empty().copyWith(hosts: [host('conflict', 'Original')]),
+      timestamp: 100,
+    );
+    final desktopSnapshot = original.copyWith(hosts: []);
+    final mobileEdited = stampLocalVaultChanges(
+      original,
+      original.copyWith(hosts: [host('conflict', 'Edited on mobile')]),
+      timestamp: 400,
+    );
+
+    final merged = mergeVaults(
+      local: mobileEdited,
+      remote: desktopSnapshot,
+      remoteFallbackTimestamp: 300,
+    );
+
+    expect(merged.hosts.single.label, 'Edited on mobile');
+    expect(
+      VaultSyncState.fromVault(merged).deletedAt(
+        VaultSyncState.hosts,
+        'conflict',
+      ),
+      0,
+    );
+  });
+
   test('independent additions from two devices are preserved', () {
     final left = stampLocalVaultChanges(
       VaultData.empty(),


### PR DESCRIPTION
本次更新为 SFTP 增加 Unix 权限修改、文件路径复制和当前目录跳转对应终端并自动 cd；同时修复桌面端已删除的主机、密钥和分组在手机同步后被旧缓存重新写回的问题，并保留较新移动端编辑的冲突保护。已通过 SFTP/本地化测试 14 项、保险库合并与云同步测试 16 项，以及相关代码静态分析。