### PR TITLE
修复 tmux 触摸滚动与复制，更新版本至 1.4.6

### DIFF
--- a/lib/infrastructure/ssh/system_management_service.dart
+++ b/lib/infrastructure/ssh/system_management_service.dart
@@ -963,10 +963,15 @@ class SystemManagementService {
         'tmux kill-session -t ${shellQuote(name)}',
       ).then((_) {});
 
-  String tmuxAttachCommand(String name) =>
-      'tmux set-option -t ${shellQuote('=$name')} mouse on '
-      r'\; '
-      'attach-session -t ${shellQuote('=$name')}';
+  String tmuxAttachCommand(String name) {
+    // set-option resolves a target-pane, not a target-session. The colon is
+    // essential: without it "=name" is parsed as a pane/window name and the
+    // exact-session marker is never stripped before the session fallback.
+    final target = shellQuote('=$name:');
+    return 'tmux set-option -t $target mouse on '
+        r'\; '
+        'attach-session -t $target';
+  }
 
   Future<_RemoteResult> _executeTmuxSession(
     ActiveTerminalSession session,

--- a/lib/infrastructure/ssh/system_management_service.dart
+++ b/lib/infrastructure/ssh/system_management_service.dart
@@ -964,7 +964,9 @@ class SystemManagementService {
       ).then((_) {});
 
   String tmuxAttachCommand(String name) =>
-      'tmux attach-session -t ${shellQuote(name)}';
+      'tmux set-option -t ${shellQuote('=$name')} mouse on '
+      r'\; '
+      'attach-session -t ${shellQuote('=$name')}';
 
   Future<_RemoteResult> _executeTmuxSession(
     ActiveTerminalSession session,

--- a/lib/presentation/localization/translations_en.dart
+++ b/lib/presentation/localization/translations_en.dart
@@ -497,6 +497,8 @@ const englishTranslations = <String, String>{
   '粘贴': 'Paste',
   '复制': 'Copy',
   '已复制终端文本': 'Terminal text copied',
+  '选择并复制': 'Select and copy',
+  '复制全部': 'Copy all',
   '正在建立安全连接…': 'Establishing a secure connection…',
   '终止连接': 'Cancel connection',
   '连接已由用户终止': 'Connection cancelled by the user',

--- a/lib/presentation/screens/terminal_screen.dart
+++ b/lib/presentation/screens/terminal_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:flutter/gestures.dart';
 
 import 'package:flutter/material.dart';
 import 'package:netcatty_mobile/presentation/localization/localized_widgets.dart';

--- a/lib/presentation/screens/terminal_screen_pane.dart
+++ b/lib/presentation/screens/terminal_screen_pane.dart
@@ -303,7 +303,8 @@ class _TerminalPaneState extends State<_TerminalPane> {
       color: paneBackground,
       child: AnimatedBuilder(
         animation: Listenable.merge([_controller, _scrollController]),
-        builder: (context, _) {
+        child: _terminalContent(terminalTheme),
+        builder: (context, terminalContent) {
           final selection = _controller
               .selectionFor(widget.session.terminal.buffer)
               ?.normalized;
@@ -318,55 +319,7 @@ class _TerminalPaneState extends State<_TerminalPane> {
             fit: StackFit.expand,
             clipBehavior: Clip.none,
             children: [
-              Listener(
-                  onPointerDown: (event) {
-                    // Touch belongs to local selection; only physical mouse
-                    // clicks should be forwarded to tmux/TUI applications.
-                    _controller.setPointerInputs(PointerInputs({
-                      PointerInput.scroll,
-                      if (event.kind == PointerDeviceKind.mouse)
-                        PointerInput.tap,
-                    }));
-                    _copyHoldTimer?.cancel();
-                    if (_alternateScreen &&
-                        !widget.pictureInPicture &&
-                        event.kind == PointerDeviceKind.touch) {
-                      _copyHoldOrigin = event.position;
-                      final snapshot = widget.session.terminal.buffer.getText();
-                      _copyHoldTimer = Timer(const Duration(milliseconds: 550),
-                          () => _showCopySnapshot(snapshot));
-                    }
-                  },
-                  onPointerMove: (event) {
-                    if (_copyHoldOrigin != null &&
-                        (event.position - _copyHoldOrigin!).distance >
-                            kTouchSlop) {
-                      _copyHoldTimer?.cancel();
-                    }
-                  },
-                  onPointerUp: (_) => _copyHoldTimer?.cancel(),
-                  onPointerCancel: (_) => _copyHoldTimer?.cancel(),
-                  child: TerminalView(
-                    widget.session.terminal,
-                    // Never turn a finger swipe into shell history navigation.
-                    simulateScroll: false,
-                    key: _terminalViewKey,
-                    controller: _controller,
-                    scrollController: _scrollController,
-                    theme: terminalTheme,
-                    backgroundOpacity: widget.transparentBackground ? 0 : 1,
-                    keyboardAppearance: Theme.of(context).brightness,
-                    keyboardType: widget.secureKeyboard
-                        ? TextInputType.visiblePassword
-                        : TextInputType.emailAddress,
-                    deleteDetection: true,
-                    autofocus: !widget.pictureInPicture,
-                    padding: const EdgeInsets.all(8),
-                    textStyle: TerminalStyle(
-                      fontSize: widget.fontSize,
-                      fontFamily: 'monospace',
-                    ),
-                  )),
+              terminalContent!,
               if (!widget.pictureInPicture && startHandle != null)
                 _TerminalSelectionHandle(
                   key: const ValueKey('terminal-selection-handle-start'),
@@ -406,11 +359,63 @@ class _TerminalPaneState extends State<_TerminalPane> {
     );
   }
 
-  Future<void> _showCopySnapshot([String? snapshot]) async {
+  Widget _terminalContent(TerminalTheme theme) => Listener(
+        onPointerDown: (event) {
+          final mouse = event.kind == PointerDeviceKind.mouse;
+          // Switching input devices changes policy; repeated finger gestures do not.
+          if (_controller.pointerInput.inputs.contains(PointerInput.tap) !=
+              mouse) {
+            _controller.setPointerInputs(PointerInputs({
+              PointerInput.scroll,
+              if (mouse) PointerInput.tap,
+            }));
+          }
+          _copyHoldTimer?.cancel();
+          if (_alternateScreen &&
+              !widget.pictureInPicture &&
+              event.kind == PointerDeviceKind.touch) {
+            _copyHoldOrigin = event.position;
+            // Extract text only after the hold is recognized, never on a swipe.
+            _copyHoldTimer =
+                Timer(const Duration(milliseconds: 550), _showCopySnapshot);
+          }
+        },
+        onPointerMove: (event) {
+          if (_copyHoldOrigin != null &&
+              (event.position - _copyHoldOrigin!).distance > kTouchSlop) {
+            _copyHoldTimer?.cancel();
+            _copyHoldOrigin = null;
+          }
+        },
+        onPointerUp: (_) => _copyHoldTimer?.cancel(),
+        onPointerCancel: (_) => _copyHoldTimer?.cancel(),
+        child: RepaintBoundary(
+          child: TerminalView(
+            widget.session.terminal,
+            simulateScroll: false,
+            key: _terminalViewKey,
+            controller: _controller,
+            scrollController: _scrollController,
+            theme: theme,
+            backgroundOpacity: widget.transparentBackground ? 0 : 1,
+            keyboardAppearance: Theme.of(context).brightness,
+            keyboardType: widget.secureKeyboard
+                ? TextInputType.visiblePassword
+                : TextInputType.emailAddress,
+            deleteDetection: true,
+            autofocus: !widget.pictureInPicture,
+            padding: const EdgeInsets.all(8),
+            textStyle: TerminalStyle(
+                fontSize: widget.fontSize, fontFamily: 'monospace'),
+          ),
+        ),
+      );
+
+  Future<void> _showCopySnapshot() async {
     if (!mounted || _copySnapshotOpen) return;
     _copyHoldTimer?.cancel();
     _copySnapshotOpen = true;
-    final text = snapshot ?? widget.session.terminal.buffer.getText();
+    final text = widget.session.terminal.buffer.getText();
     try {
       await showModalBottomSheet<void>(
         context: context,

--- a/lib/presentation/screens/terminal_screen_pane.dart
+++ b/lib/presentation/screens/terminal_screen_pane.dart
@@ -179,7 +179,9 @@ class _TerminalPane extends StatefulWidget {
 }
 
 class _TerminalPaneState extends State<_TerminalPane> {
-  final _controller = TerminalController();
+  final _controller = TerminalController(
+    pointerInputs: const PointerInputs({PointerInput.scroll}),
+  );
   var _terminalViewKey = GlobalKey<TerminalViewState>();
   final _terminalStackKey = GlobalKey();
   final _scrollController = ScrollController();
@@ -225,6 +227,10 @@ class _TerminalPaneState extends State<_TerminalPane> {
   }
 
   void _onTerminalChanged() {
+    if (_controller.selection != null &&
+        _controller.selectionFor(widget.session.terminal.buffer) == null) {
+      _controller.clearSelection();
+    }
     if (!widget.pictureInPicture || _pictureInPictureUpdateTimer != null) {
       return;
     }
@@ -287,7 +293,9 @@ class _TerminalPaneState extends State<_TerminalPane> {
       child: AnimatedBuilder(
         animation: Listenable.merge([_controller, _scrollController]),
         builder: (context, _) {
-          final selection = _controller.selection?.normalized;
+          final selection = _controller
+              .selectionFor(widget.session.terminal.buffer)
+              ?.normalized;
           final startHandle = selection == null
               ? null
               : _selectionHandlePosition(selection.begin);
@@ -299,25 +307,37 @@ class _TerminalPaneState extends State<_TerminalPane> {
             fit: StackFit.expand,
             clipBehavior: Clip.none,
             children: [
-              TerminalView(
-                widget.session.terminal,
-                key: _terminalViewKey,
-                controller: _controller,
-                scrollController: _scrollController,
-                theme: terminalTheme,
-                backgroundOpacity: widget.transparentBackground ? 0 : 1,
-                keyboardAppearance: Theme.of(context).brightness,
-                keyboardType: widget.secureKeyboard
-                    ? TextInputType.visiblePassword
-                    : TextInputType.emailAddress,
-                deleteDetection: true,
-                autofocus: !widget.pictureInPicture,
-                padding: const EdgeInsets.all(8),
-                textStyle: TerminalStyle(
-                  fontSize: widget.fontSize,
-                  fontFamily: 'monospace',
-                ),
-              ),
+              Listener(
+                  onPointerDown: (event) {
+                    // Touch belongs to local selection; only physical mouse
+                    // clicks should be forwarded to tmux/TUI applications.
+                    _controller.setPointerInputs(PointerInputs({
+                      PointerInput.scroll,
+                      if (event.kind == PointerDeviceKind.mouse)
+                        PointerInput.tap,
+                    }));
+                  },
+                  child: TerminalView(
+                    widget.session.terminal,
+                    // Never turn a finger swipe into shell history navigation.
+                    simulateScroll: false,
+                    key: _terminalViewKey,
+                    controller: _controller,
+                    scrollController: _scrollController,
+                    theme: terminalTheme,
+                    backgroundOpacity: widget.transparentBackground ? 0 : 1,
+                    keyboardAppearance: Theme.of(context).brightness,
+                    keyboardType: widget.secureKeyboard
+                        ? TextInputType.visiblePassword
+                        : TextInputType.emailAddress,
+                    deleteDetection: true,
+                    autofocus: !widget.pictureInPicture,
+                    padding: const EdgeInsets.all(8),
+                    textStyle: TerminalStyle(
+                      fontSize: widget.fontSize,
+                      fontFamily: 'monospace',
+                    ),
+                  )),
               if (!widget.pictureInPicture && startHandle != null)
                 _TerminalSelectionHandle(
                   key: const ValueKey('terminal-selection-handle-start'),
@@ -438,7 +458,7 @@ class _TerminalPaneState extends State<_TerminalPane> {
   }
 
   Future<void> _copySelection() async {
-    final selection = _controller.selection;
+    final selection = _controller.selectionFor(widget.session.terminal.buffer);
     if (selection == null) return;
     final text = widget.session.terminal.buffer.getText(selection);
     if (text.isEmpty) return;

--- a/lib/presentation/screens/terminal_screen_pane.dart
+++ b/lib/presentation/screens/terminal_screen_pane.dart
@@ -187,10 +187,15 @@ class _TerminalPaneState extends State<_TerminalPane> {
   final _scrollController = ScrollController();
   Offset? _dragPointerToAnchor;
   Timer? _pictureInPictureUpdateTimer;
+  Timer? _copyHoldTimer;
+  Offset? _copyHoldOrigin;
+  bool _copySnapshotOpen = false;
+  late bool _alternateScreen;
 
   @override
   void initState() {
     super.initState();
+    _alternateScreen = widget.session.terminal.isUsingAltBuffer;
     widget.session.terminal.addListener(_onTerminalChanged);
     if (widget.pictureInPicture) {
       WidgetsBinding.instance.addPostFrameCallback((_) => _sendPipUpdate());
@@ -221,12 +226,18 @@ class _TerminalPaneState extends State<_TerminalPane> {
   void dispose() {
     widget.session.terminal.removeListener(_onTerminalChanged);
     _pictureInPictureUpdateTimer?.cancel();
+    _copyHoldTimer?.cancel();
     _controller.dispose();
     _scrollController.dispose();
     super.dispose();
   }
 
   void _onTerminalChanged() {
+    final alternate = widget.session.terminal.isUsingAltBuffer;
+    if (alternate != _alternateScreen) {
+      _copyHoldTimer?.cancel();
+      setState(() => _alternateScreen = alternate);
+    }
     if (_controller.selection != null &&
         _controller.selectionFor(widget.session.terminal.buffer) == null) {
       _controller.clearSelection();
@@ -316,7 +327,25 @@ class _TerminalPaneState extends State<_TerminalPane> {
                       if (event.kind == PointerDeviceKind.mouse)
                         PointerInput.tap,
                     }));
+                    _copyHoldTimer?.cancel();
+                    if (_alternateScreen &&
+                        !widget.pictureInPicture &&
+                        event.kind == PointerDeviceKind.touch) {
+                      _copyHoldOrigin = event.position;
+                      final snapshot = widget.session.terminal.buffer.getText();
+                      _copyHoldTimer = Timer(const Duration(milliseconds: 550),
+                          () => _showCopySnapshot(snapshot));
+                    }
                   },
+                  onPointerMove: (event) {
+                    if (_copyHoldOrigin != null &&
+                        (event.position - _copyHoldOrigin!).distance >
+                            kTouchSlop) {
+                      _copyHoldTimer?.cancel();
+                    }
+                  },
+                  onPointerUp: (_) => _copyHoldTimer?.cancel(),
+                  onPointerCancel: (_) => _copyHoldTimer?.cancel(),
                   child: TerminalView(
                     widget.session.terminal,
                     // Never turn a finger swipe into shell history navigation.
@@ -356,13 +385,16 @@ class _TerminalPaneState extends State<_TerminalPane> {
                   onPanUpdate: (details) => _updateHandleDrag(false, details),
                   onPanEnd: _endHandleDrag,
                 ),
-              if (!widget.pictureInPicture && selection != null)
+              if (!widget.pictureInPicture &&
+                  (selection != null || _alternateScreen))
                 Positioned(
                   top: 10,
                   right: 10,
                   child: FilledButton.tonalIcon(
                     key: const ValueKey('copy-terminal-selection'),
-                    onPressed: _copySelection,
+                    onPressed: _alternateScreen
+                        ? () => _showCopySnapshot()
+                        : _copySelection,
                     icon: const Icon(Icons.copy_outlined, size: 18),
                     label: const LText('复制'),
                   ),
@@ -372,6 +404,23 @@ class _TerminalPaneState extends State<_TerminalPane> {
         },
       ),
     );
+  }
+
+  Future<void> _showCopySnapshot([String? snapshot]) async {
+    if (!mounted || _copySnapshotOpen) return;
+    _copyHoldTimer?.cancel();
+    _copySnapshotOpen = true;
+    final text = snapshot ?? widget.session.terminal.buffer.getText();
+    try {
+      await showModalBottomSheet<void>(
+        context: context,
+        isScrollControlled: true,
+        useSafeArea: true,
+        builder: (_) => _TerminalCopySheet(text: text),
+      );
+    } finally {
+      _copySnapshotOpen = false;
+    }
   }
 
   Offset? _selectionHandlePosition(CellOffset offset) {
@@ -472,6 +521,70 @@ class _TerminalPaneState extends State<_TerminalPane> {
       ),
     );
   }
+}
+
+class _TerminalCopySheet extends StatefulWidget {
+  const _TerminalCopySheet({required this.text});
+  final String text;
+  @override
+  State<_TerminalCopySheet> createState() => _TerminalCopySheetState();
+}
+
+class _TerminalCopySheetState extends State<_TerminalCopySheet> {
+  late final _text = TextEditingController(text: widget.text);
+  @override
+  void dispose() {
+    _text.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) => FractionallySizedBox(
+        heightFactor: .8,
+        child: Column(children: [
+          Row(children: [
+            const SizedBox(width: 16),
+            const Expanded(child: LText('选择并复制')),
+            ValueListenableBuilder<TextEditingValue>(
+              valueListenable: _text,
+              builder: (_, value, child) => TextButton(
+                key: const ValueKey('copy-terminal-snapshot'),
+                onPressed: () async {
+                  final selection = value.selection;
+                  final text = selection.isValid && !selection.isCollapsed
+                      ? selection.textInside(value.text)
+                      : value.text;
+                  await Clipboard.setData(ClipboardData(text: text));
+                  if (context.mounted) Navigator.pop(context);
+                },
+                child: LText(
+                    value.selection.isValid && !value.selection.isCollapsed
+                        ? '复制'
+                        : '复制全部'),
+              ),
+            ),
+            IconButton(
+                tooltip: localized('关闭'),
+                onPressed: () => Navigator.pop(context),
+                icon: const Icon(Icons.close)),
+          ]),
+          Expanded(
+              child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16),
+            child: TextField(
+              key: const ValueKey('terminal-copy-snapshot'),
+              controller: _text,
+              readOnly: true,
+              showCursor: false,
+              expands: true,
+              maxLines: null,
+              minLines: null,
+              style: const TextStyle(fontFamily: 'monospace'),
+              decoration: const InputDecoration(border: InputBorder.none),
+            ),
+          )),
+        ]),
+      );
 }
 
 class _TerminalSelectionHandle extends StatelessWidget {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: netcatty_mobile
 description: Netcatty mobile SSH, SFTP and cloud-sync client for Android and iOS.
 publish_to: none
-version: 1.4.5+24
+version: 1.4.6+25
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/test/system_management_service_test.dart
+++ b/test/system_management_service_test.dart
@@ -10,9 +10,20 @@ void main() {
       () {
     final command = SystemManagementService().tmuxAttachCommand('work');
     expect(command,
-        "tmux set-option -t '=work' mouse on \\; attach-session -t '=work'");
+        "tmux set-option -t '=work:' mouse on \\; attach-session -t '=work:'");
     expect(command, isNot(contains(' -g ')));
     expect(command, isNot(contains('.tmux.conf')));
+  });
+  test('tmux attach disambiguates session names from pane and window targets',
+      () {
+    final service = SystemManagementService();
+    for (final name in ['nq', '0', 'work', 'work-long', 'two words']) {
+      final command = service.tmuxAttachCommand(name);
+      expect(command,
+          "tmux set-option -t '=$name:' mouse on \\; attach-session -t '=$name:'");
+    }
+    final quoted = service.tmuxAttachCommand("user's session");
+    expect(quoted, contains("'=user'\\''s session:'"));
   });
   late SystemManagementService service;
 

--- a/test/system_management_service_test.dart
+++ b/test/system_management_service_test.dart
@@ -5,6 +5,15 @@ import 'package:netcatty_mobile/domain/models/system_management.dart';
 import 'package:netcatty_mobile/infrastructure/ssh/system_management_service.dart';
 
 void main() {
+  test(
+      'tmux attach enables only target session mouse support with exact target',
+      () {
+    final command = SystemManagementService().tmuxAttachCommand('work');
+    expect(command,
+        "tmux set-option -t '=work' mouse on \\; attach-session -t '=work'");
+    expect(command, isNot(contains(' -g ')));
+    expect(command, isNot(contains('.tmux.conf')));
+  });
   late SystemManagementService service;
 
   setUp(() => service = SystemManagementService());

--- a/test/terminal_connection_dialog_test.dart
+++ b/test/terminal_connection_dialog_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:netcatty_mobile/application/session_controller.dart';
@@ -311,6 +312,49 @@ void main() {
         find.byKey(const ValueKey('copy-terminal-selection')),
         findsOneWidget,
       );
+
+      // tmux uses the alternate screen. A swipe must never become arrow keys,
+      // including when the remote application has not enabled mouse reporting.
+      final sent = <String>[];
+      existing.terminal.onOutput = sent.add;
+      existing.terminal.write('\x1b[?1049h\x1b[Halpha beta gamma');
+      await tester.pump();
+      sent.clear();
+      await tester.drag(find.byType(TerminalView), const Offset(0, -100));
+      await tester.pump();
+      expect(sent, isEmpty);
+
+      // With tmux mouse reporting enabled, scroll events still reach tmux,
+      // but touching text does not send a remote click that disrupts selection.
+      existing.terminal.write('\x1b[?1000h\x1b[?1006h');
+      await tester.pump();
+      await tester.drag(find.byType(TerminalView), const Offset(0, -100));
+      await tester.pump();
+      expect(sent, isNotEmpty);
+      expect(sent.every((event) => event.startsWith('\x1b[<')), isTrue);
+      sent.clear();
+      await tester.longPressAt(wordPosition);
+      await tester.pump();
+      expect(sent, isEmpty);
+      expect(find.byKey(const ValueKey('copy-terminal-selection')),
+          findsOneWidget);
+      String? copiedText;
+      tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        SystemChannels.platform,
+        (call) async {
+          if (call.method == 'Clipboard.setData') {
+            copiedText = (call.arguments as Map)['text'] as String;
+          }
+          return null;
+        },
+      );
+      addTearDown(() => tester.binding.defaultBinaryMessenger
+          .setMockMethodCallHandler(SystemChannels.platform, null));
+      await tester.tap(find.byKey(const ValueKey('copy-terminal-selection')));
+      await tester.pump();
+      expect(copiedText, 'alpha');
+      existing.terminal.write('\x1b[?1000l\x1b[?1006l\x1b[?1049l');
+      await tester.pump();
 
       expect(
         find.byKey(const ValueKey('terminal-tab-strip')),

--- a/test/terminal_connection_dialog_test.dart
+++ b/test/terminal_connection_dialog_test.dart
@@ -328,14 +328,22 @@ void main() {
       // but touching text does not send a remote click that disrupts selection.
       existing.terminal.write('\x1b[?1000h\x1b[?1006h');
       await tester.pump();
+      final viewBeforeScroll =
+          tester.widget<TerminalView>(find.byType(TerminalView));
       await tester.drag(find.byType(TerminalView), const Offset(0, -100));
       await tester.pump();
+      expect(tester.widget<TerminalView>(find.byType(TerminalView)),
+          same(viewBeforeScroll));
       expect(sent, isNotEmpty);
       expect(sent.every((event) => event.startsWith('\x1b[<')), isTrue);
       expect(
           find.byKey(const ValueKey('terminal-copy-snapshot')), findsNothing);
       sent.clear();
-      await tester.longPressAt(wordPosition);
+      final hold = await tester.startGesture(wordPosition);
+      await tester.pump(const Duration(milliseconds: 200));
+      existing.terminal.write('\x1b[Halpha beta updated');
+      await tester.pump(const Duration(milliseconds: 400));
+      await hold.up();
       await tester.pumpAndSettle();
       expect(sent, isEmpty);
       expect(find.byKey(const ValueKey('copy-terminal-selection')),
@@ -356,7 +364,8 @@ void main() {
           find.byKey(const ValueKey('terminal-copy-snapshot')));
       expect(snapshot.readOnly, isTrue);
       final captured = snapshot.controller!.text;
-      expect(captured, contains('alpha beta gamma'));
+      // Snapshot is captured after recognizing a hold, not on every touch-down.
+      expect(captured, contains('alpha beta updated'));
       // A tmux redraw must not change the text being selected/copied.
       existing.terminal.write('\x1b[2J\x1b[Hnew tmux output');
       await tester.pump();

--- a/test/terminal_connection_dialog_test.dart
+++ b/test/terminal_connection_dialog_test.dart
@@ -332,9 +332,11 @@ void main() {
       await tester.pump();
       expect(sent, isNotEmpty);
       expect(sent.every((event) => event.startsWith('\x1b[<')), isTrue);
+      expect(
+          find.byKey(const ValueKey('terminal-copy-snapshot')), findsNothing);
       sent.clear();
       await tester.longPressAt(wordPosition);
-      await tester.pump();
+      await tester.pumpAndSettle();
       expect(sent, isEmpty);
       expect(find.byKey(const ValueKey('copy-terminal-selection')),
           findsOneWidget);
@@ -350,9 +352,33 @@ void main() {
       );
       addTearDown(() => tester.binding.defaultBinaryMessenger
           .setMockMethodCallHandler(SystemChannels.platform, null));
-      await tester.tap(find.byKey(const ValueKey('copy-terminal-selection')));
+      final snapshot = tester.widget<TextField>(
+          find.byKey(const ValueKey('terminal-copy-snapshot')));
+      expect(snapshot.readOnly, isTrue);
+      final captured = snapshot.controller!.text;
+      expect(captured, contains('alpha beta gamma'));
+      // A tmux redraw must not change the text being selected/copied.
+      existing.terminal.write('\x1b[2J\x1b[Hnew tmux output');
       await tester.pump();
+      expect(snapshot.controller!.text, captured);
+      snapshot.controller!.selection =
+          const TextSelection(baseOffset: 0, extentOffset: 5);
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('copy-terminal-snapshot')));
+      await tester.pumpAndSettle();
       expect(copiedText, 'alpha');
+      // Explicit entry also works without an xterm selection, and supports copy all.
+      await tester.tap(find.byKey(const ValueKey('copy-terminal-selection')));
+      await tester.pumpAndSettle();
+      final updated = tester
+          .widget<TextField>(
+              find.byKey(const ValueKey('terminal-copy-snapshot')))
+          .controller!
+          .text;
+      expect(updated, contains('new tmux output'));
+      await tester.tap(find.byKey(const ValueKey('copy-terminal-snapshot')));
+      await tester.pumpAndSettle();
+      expect(copiedText, updated);
       existing.terminal.write('\x1b[?1000l\x1b[?1006l\x1b[?1049l');
       await tester.pump();
 


### PR DESCRIPTION
## 更新内容

- 版本号更新为 `1.4.6+25`，设置页通过应用版本信息自动显示。
- 关闭备用终端屏幕滑动转上下方向键的默认行为，避免进入 tmux 后滑动变成切换历史命令。
- 触摸长按选择由手机端处理，保留实体鼠标点击及远端滚轮事件，避免 tmux 鼠标事件干扰本地选择和复制。
- 从系统管理面板进入 tmux 时，为精确匹配的目标会话开启 mouse 选项；不修改全局选项、快捷键绑定或 `.tmux.conf`。该会话的其他已连接客户端也会使用此会话选项。
- 普通屏幕与 tmux 备用屏幕之间隔离选区，避免跨屏幕复制旧选区。

## 验证

- 终端交互与系统管理针对性测试 25 项通过。
- 最后的屏幕切换选区清理补丁追加 8 项终端回归通过。
- 静态检查通过。
- 本地 Android debug 编译通过（版本 1.4.6）。

## 建议真机验证

- 从系统管理面板进入 tmux，上下滑动查看历史输出，确认不会切换 shell 历史命令。
- 长按文字、拖动选区并复制到手机剪贴板。
- 退出 tmux 后确认普通终端的滚动和复制正常。
- Android/iOS 安装包由本 PR 的 Mobile CI 构建。
